### PR TITLE
docs: add /research slash command to course content

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -360,6 +360,7 @@ These commands work in interactive mode. **Start with just these four** - they c
 | `/help` | Show all available commands | When you forget a command |
 | `/clear` | Clear conversation and start fresh | When switching topics |
 | `/plan` | Plan your work out before coding | For more complex features |
+| `/research` | Deep research using GitHub and web sources | When you need to investigate a topic before coding |
 | `/model` | Show or switch AI model | When you want to change the AI model |
 | `/exit` | End the session | When you're done |
 
@@ -398,6 +399,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 |---------|--------------|
 | `/diff` | Review the changes made in the current directory |
 | `/review` | Run the code-review agent to analyze changes |
+| `/research` | Run deep research investigation using GitHub and web sources |
 | `/terminal-setup` | Enable multiline input support (shift+enter and ctrl+enter) |
 
 ### Permissions

--- a/03-development-workflows/README.md
+++ b/03-development-workflows/README.md
@@ -49,6 +49,7 @@ This chapter covers five workflows that developers typically use. **However, you
 | Track down and fix a bug | [Workflow 3: Debugging](#workflow-3-debugging) |
 | Generate tests for my code | [Workflow 4: Test Generation](#workflow-4-test-generation) |
 | Write better commits and PRs | [Workflow 5: Git Integration](#workflow-5-git-integration) |
+| Research before coding | [Quick Tip: Research Before You Plan or Code](#quick-tip-research-before-you-plan-or-code) |
 | See a full bug-fix workflow end to end | [Putting It All Together](#putting-it-all-together-bug-fix-workflow) |
 
 **Select a workflow below to expand it** and see how GitHub Copilot CLI can enhance your development process in that area. 
@@ -682,6 +683,22 @@ copilot
 ```
 
 </details>
+
+---
+
+## Quick Tip: Research Before You Plan or Code
+
+When you need to investigate a library, understand best practices, or explore an unfamiliar topic, use `/research` to run a deep research investigation before writing any code:
+
+```bash
+copilot
+
+> /research What are the best Python libraries for validating user input in CLI apps?
+```
+
+Copilot searches GitHub repositories and web sources, then returns a summary with references. This is useful when you're about to start a new feature and want to make informed decisions first. You can share the results using `/share`.
+
+> 💡 **Tip**: `/research` works well *before* `/plan`. Research the approach, then plan the implementation.
 
 ---
 

--- a/07-putting-it-together/README.md
+++ b/07-putting-it-together/README.md
@@ -139,19 +139,19 @@ copilot
 
 # Learn: "find_by_author doesn't work with partial names"
 
-# PHASE 2: Find related code
+# PHASE 2: Research best practice (deep research with web + GitHub sources)
+> /research Best practices for Python case-insensitive string matching
+
+# PHASE 3: Find related code
 > @samples/book-app-project/books.py Show me the find_by_author method
 
-# PHASE 3: Get expert analysis
+# PHASE 4: Get expert analysis
 > /agent
 # Select "python-reviewer"
 
 > Analyze this method for issues with partial name matching
 
 # Agent identifies: Method uses exact equality instead of substring matching
-
-# PHASE 4: Research best practice
-> What are the best practices for Python case-insensitive string matching?
 
 # PHASE 5: Fix with agent guidance
 > Implement the fix using lowercase comparison and 'in' operator


### PR DESCRIPTION
## Summary

Integrates the `/research` slash command across three chapters of the course. The additions are concise — a command table entry, a quick tip section, and a workflow example.

## Changes

### Chapter 01 (First Steps)
- Added `/research` to the **Essential Slash Commands** table
- Added `/research` to the **Additional Commands > Code** reference table

### Chapter 03 (Development Workflows)
- Added a **"Quick Tip: Research Before You Code"** section between Workflow 5 and "Putting It All Together"
- Shows a single practical example and the `/research` → `/plan` pattern
- Added a row in the "Choose Your Own Adventure" table linking to the new section

### Chapter 07 (Putting It All Together)
- Updated the **Bug Investigation workflow** to use `/research` in Phase 2 (before switching into an agent), showing it naturally in an end-to-end workflow

## Why this placement

- **Ch 01**: Beginners see it exists from day one alongside `/help`, `/plan`, `/clear`
- **Ch 03**: The standalone quick tip keeps it lightweight without adding a full sixth workflow
- **Ch 07**: Using `/research` before `/agent` in the bug fix flow shows the real-world pattern: research first, then bring in specialists