### PR TITLE
docs: improve /fleet command description and add tip in Ch07

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -390,7 +390,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 |---------|--------------|
 | `/model` | Show or switch AI model |
 | `/delegate` | Hand off task to Copilot coding agent on GitHub (agent in the cloud) |
-| `/fleet` | Enable fleet mode for parallel subagent execution |
+| `/fleet` | Split a complex task into parallel subtasks for faster completion |
 | `/tasks` | View background subagents and detached shell sessions |
 
 ### Code

--- a/07-putting-it-together/README.md
+++ b/07-putting-it-together/README.md
@@ -100,6 +100,8 @@ copilot
 
 **The key insight**: You directed specialists like an architect. They handled the details. You handled the vision.
 
+> 💡 **Going further**: For large multi-step plans like this, try `/fleet` to let Copilot run independent subtasks in parallel. See the [official docs](https://docs.github.com/copilot/concepts/agents/copilot-cli/fleet) for details.
+
 ---
 
 <details>


### PR DESCRIPTION
## Summary

Minor improvements to how `/fleet` is presented in the course, keeping it lightweight for beginners.

## Changes

### Chapter 01 (First Steps)
- Reworded the `/fleet` entry in the Additional Commands table from *"Enable fleet mode for parallel subagent execution"* to *"Split a complex task into parallel subtasks for faster completion"* — more approachable for beginners

### Chapter 07 (Putting It All Together)
- Added a one-line 💡 callout tip after the "Idea to Merged PR" workflow, pointing motivated learners to the [official /fleet docs](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/fleet)

## Why these changes

Based on research into `/fleet`, it's too advanced for dedicated beginner coverage (requires understanding of plan mode, agents, context windows, and premium request billing). The existing table entry is the right level of exposure — these edits just make it friendlier and give a breadcrumb for learners who want to explore further.