### PR TITLE
docs: expand --resume session guidance in Chapter 02

### DIFF
--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -307,6 +307,16 @@ copilot --resume
 copilot --resume abc123
 ```
 
+> 💡 **How do I find a session ID?** You don't need to memorize them. Running `copilot --resume` without an ID shows an interactive list of your previous sessions, their names, IDs, and when they were last active. Just pick the one you want.
+>
+> **What about multiple terminals?** Each terminal window is its own session with its own context. If you have Copilot CLI open in three terminals, that's three separate sessions. Running `--resume` from any terminal lets you browse all of them. The `--continue` flag grabs whichever session was closed most recently, no matter which terminal it was in.
+>
+> **Can I switch sessions without restarting?** Yes. Use the `/resume` slash command from inside an active session:
+> ```
+> > /resume
+> # Shows a list of sessions to switch to
+> ```
+
 ### Organize Your Sessions
 
 Give sessions meaningful names so you can find them later:
@@ -428,17 +438,6 @@ For power users, Copilot CLI supports wildcard patterns and image references:
 copilot
 
 > Find all TODO comments in @samples/book-app-project/**/*.py
-```
-
-### Switch Sessions While Working
-
-Inside an interactive session, use the `/resume` command:
-
-```bash
-copilot
-
-> /resume
-# Shows a list of sessions to switch to
 ```
 
 ### View Session Info


### PR DESCRIPTION
## Summary

Expands the `--resume` / `--continue` session management section in Chapter 02 based on reader feedback asking for more clarity on:

- **How to find session IDs** — explains that `copilot --resume` shows an interactive list (no memorization needed)
- **Multiple terminals** — clarifies that each terminal is its own session, and `--resume` browses all saved sessions across terminals
- **Switching mid-session** — documents the `/resume` slash command for switching without restarting

Also removes the now-redundant "Switch Sessions While Working" subsection from the optional deeper section to avoid duplication.

## Feedback addressed

> "Might be helpful to explain how the resume of a copilot session works when you have multiple terminals and copilot sessions. And when you mention resuming by id, might be helpful to say how they know that id."