### PR TITLE
docs: add /pr command mentions to course chapters

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -402,6 +402,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 | Command | What It Does |
 |---------|--------------|
 | `/diff` | Review the changes made in the current directory |
+| `/pr` | Operate on pull requests for the current branch |
 | `/review` | Run the code-review agent to analyze changes |
 | `/research` | Run deep research investigation using GitHub and web sources |
 | `/terminal-setup` | Enable multiline input support (shift+enter and ctrl+enter) |

--- a/03-development-workflows/README.md
+++ b/03-development-workflows/README.md
@@ -571,7 +571,7 @@ copilot
 
 <a id="workflow-5-git-integration"></a>
 <details>
-<summary><strong>Workflow 5: Git Integration</strong> - Commit messages, PR descriptions, /delegate, and /diff</summary>
+<summary><strong>Workflow 5: Git Integration</strong> - Commit messages, PR descriptions, /pr, /delegate, and /diff</summary>
 
 <img src="images/git-integration-swimlane-single.png" alt="Git Integration workflow: stage changes, generate message, commit, create PR." width="800"/>
 
@@ -635,6 +635,16 @@ Include:
 - Why these changes were made
 - Testing done
 - Breaking changes? (yes/no)"
+```
+
+### Using /pr in Interactive Mode for the Current Branch
+
+If you're working with a branch in Copilot CLI's interactive mode, you can use the `/pr` command to work with pull requests. Use `/pr` to view a PR, create a new PR, fix an existing PR, or let Copilot CLI auto-decide based on the branch state.
+
+```bash
+copilot
+
+> /pr [view|create|fix|auto]
 ```
 
 ### Review Before Push

--- a/07-putting-it-together/README.md
+++ b/07-putting-it-together/README.md
@@ -92,7 +92,10 @@ copilot
 # Review the changes
 > /review
 
-# If review passes, generate a PR (uses GitHub MCP covered earlier in the course)
+# If review passes, use /pr to operate on the pull request for the current branch
+> /pr [view|create|fix|auto]
+
+# Or ask naturally if you want Copilot to draft it from the terminal
 > Create a pull request titled "Feature: Add list unread books command"
 ```
 


### PR DESCRIPTION
## Summary
- add `/pr` to the chapter 01 code command table
- add a short `/pr` section to the chapter 03 Git Integration workflow
- mention `/pr` in the chapter 07 end-to-end PR flow

## Testing
- not run (documentation-only changes)