### PR TITLE
Fix: Add GH_TOKEN to traffic updater agent environment

### DIFF
--- a/.github/workflows/traffic-updater.lock.yml
+++ b/.github/workflows/traffic-updater.lock.yml
@@ -22,7 +22,7 @@
 #
 # Weekly collection of repo traffic data (views and unique visitors). Appends the previous week's daily numbers to CSV files.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a8f667caacc29ffd2976f0d5af6b604671652402b021380b981a1c7eeb32bfc1","compiler_version":"v0.64.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1089cfe8d29e1afda349c3de8e753fa078fdbcf9cb4be49e4adc60e1fe139d38","compiler_version":"v0.64.4","strict":true,"agent_id":"copilot"}
 
 name: "Traffic Updater"
 "on":
@@ -126,19 +126,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_c464a40d585dee5e_EOF'
+          cat << 'GH_AW_PROMPT_537d0c7e0709e7bc_EOF'
           <system>
-          GH_AW_PROMPT_c464a40d585dee5e_EOF
+          GH_AW_PROMPT_537d0c7e0709e7bc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c464a40d585dee5e_EOF'
+          cat << 'GH_AW_PROMPT_537d0c7e0709e7bc_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_c464a40d585dee5e_EOF
+          GH_AW_PROMPT_537d0c7e0709e7bc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_c464a40d585dee5e_EOF'
+          cat << 'GH_AW_PROMPT_537d0c7e0709e7bc_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -168,14 +168,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c464a40d585dee5e_EOF
+          GH_AW_PROMPT_537d0c7e0709e7bc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c464a40d585dee5e_EOF'
+          cat << 'GH_AW_PROMPT_537d0c7e0709e7bc_EOF'
           </system>
-          GH_AW_PROMPT_c464a40d585dee5e_EOF
-          cat << 'GH_AW_PROMPT_c464a40d585dee5e_EOF'
+          GH_AW_PROMPT_537d0c7e0709e7bc_EOF
+          cat << 'GH_AW_PROMPT_537d0c7e0709e7bc_EOF'
           {{#runtime-import .github/workflows/traffic-updater.md}}
-          GH_AW_PROMPT_c464a40d585dee5e_EOF
+          GH_AW_PROMPT_537d0c7e0709e7bc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -329,12 +329,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_f14d4f09daa40f9e_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_a027400c599ed6d2_EOF'
           {"create_pull_request":{"base_branch":"main","labels":["automated-update","traffic-data"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[bot] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f14d4f09daa40f9e_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a027400c599ed6d2_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_402325576f970a45_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_2ac193913320ed75_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[bot] \". Labels [\"automated-update\" \"traffic-data\"] will be automatically added."
@@ -342,8 +342,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_402325576f970a45_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8562a0e16df79c09_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_2ac193913320ed75_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_e377cde44bc71725_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -439,7 +439,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_8562a0e16df79c09_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_e377cde44bc71725_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -507,7 +507,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_2572bf4493965c87_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_fd45b3cda1bf069e_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -548,7 +548,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_2572bf4493965c87_EOF
+          GH_AW_MCP_CONFIG_fd45b3cda1bf069e_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -600,6 +600,7 @@ jobs:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_VERSION: v0.64.4
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_AW: true
           GITHUB_HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/traffic-updater.md
+++ b/.github/workflows/traffic-updater.md
@@ -9,6 +9,10 @@ tools:
   edit:
   github:
     toolsets: [repos]
+# NOTE: After running `gh aw compile`, manually add the following env var
+# to the agent step in the lock file (the step that runs `copilot`):
+#   GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+# This is required because engine.env is not yet supported by the compiler.
 safe-outputs:
   allowed-domains:
     - github.com


### PR DESCRIPTION
The `gh` CLI inside the agentic workflow sandbox needs `GH_TOKEN` to call the Traffic API. This adds:

1. `GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}` to the agent step's env block in the lock file
2. A comment in `traffic-updater.md` reminding to re-add this after recompiles (since `engine.env` isn't supported by the compiler yet)

**Note:** Once `gh aw` supports `engine.env`, we can move this to the frontmatter and remove the manual step.