### PR TITLE
[bot] docs: document .claude/settings.json and model picker reasoning effort (CLI v1.0.12–v1.0.14)

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -464,10 +464,12 @@ Copilot CLI supports multiple AI models from OpenAI, Anthropic, Google, and othe
 copilot
 > /model
 
-# Shows available models and lets you pick one. Select Sonnet 4.5.
+# Opens a full-screen model picker. Select a model and press Enter.
 ```
 
 > 💡 **Tip**: Some models cost more "premium requests" than others. Models marked **1x** (like Claude Sonnet 4.5) are a great default. They're capable and efficient. Higher-multiplier models use your premium request quota faster, so save those for when you really need them.
+
+> 💡 **Reasoning effort**: Inside the model picker, use the ← and → arrow keys to adjust the **reasoning effort** for the selected model. Lower effort is faster; higher effort is more thorough. The current effort level is shown next to the model name in the session header (e.g., `claude-sonnet-4.5 (high)`). Start with the default and raise it only when you need deeper analysis.
 
 </details>
 

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -469,7 +469,7 @@ copilot
 
 > 💡 **Tip**: Some models cost more "premium requests" than others. Models marked **1x** (like Claude Sonnet 4.5) are a great default. They're capable and efficient. Higher-multiplier models use your premium request quota faster, so save those for when you really need them.
 
-> 💡 **Reasoning effort**: Inside the model picker, use the ← and → arrow keys to adjust the **reasoning effort** for the selected model (if supported). Lower effort is faster; higher effort is more thorough. The current effort level is shown next to the model name in the session header (e.g., `claude-sonnet-4.5 (high)`). Start with the default and raise it only when you need deeper analysis.
+> 💡 **Reasoning effort**: Inside the model picker, use the ← and → arrow keys to adjust the **reasoning effort** for the selected model (when supported). Lower effort is faster; higher effort is more thorough. The current effort level is shown next to the model name in the session header (e.g., `claude-sonnet-4.5 (high)`). Start with the default and raise it only when you need deeper analysis.
 
 </details>
 

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -469,7 +469,7 @@ copilot
 
 > 💡 **Tip**: Some models cost more "premium requests" than others. Models marked **1x** (like Claude Sonnet 4.5) are a great default. They're capable and efficient. Higher-multiplier models use your premium request quota faster, so save those for when you really need them.
 
-> 💡 **Reasoning effort**: Inside the model picker, use the ← and → arrow keys to adjust the **reasoning effort** for the selected model. Lower effort is faster; higher effort is more thorough. The current effort level is shown next to the model name in the session header (e.g., `claude-sonnet-4.5 (high)`). Start with the default and raise it only when you need deeper analysis.
+> 💡 **Reasoning effort**: Inside the model picker, use the ← and → arrow keys to adjust the **reasoning effort** for the selected model (if supported). Lower effort is faster; higher effort is more thorough. The current effort level is shown next to the model name in the session header (e.g., `claude-sonnet-4.5 (high)`). Start with the default and raise it only when you need deeper analysis.
 
 </details>
 

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -469,7 +469,7 @@ copilot
 
 > 💡 **Tip**: Some models cost more "premium requests" than others. Models marked **1x** (like Claude Sonnet 4.5) are a great default. They're capable and efficient. Higher-multiplier models use your premium request quota faster, so save those for when you really need them.
 
-> 💡 **Reasoning effort**: Inside the model picker, use the ← and → arrow keys to adjust the **reasoning effort** for the selected model (when supported). Lower effort is faster; higher effort is more thorough. The current effort level is shown next to the model name in the session header (e.g., `claude-sonnet-4.5 (high)`). Start with the default and raise it only when you need deeper analysis.
+> 💡 **Reasoning effort**: Inside the model picker, use the ← and → arrow keys to adjust the **reasoning effort** for the selected model (when supported). Lower effort is faster; higher effort is more thorough. The current effort level is shown next to the model name in the session header (e.g., `claude-sonnet-4.6 (high)`). Start with the default and raise it only when you need deeper analysis.
 
 </details>
 

--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -423,8 +423,26 @@ Copilot will scan your project and create tailored instruction files. You can ed
 | `.github/copilot-instructions.md` | Project | GitHub Copilot specific |
 | `.github/instructions/*.instructions.md` | Project | Granular, topic-specific instructions |
 | `CLAUDE.md`, `GEMINI.md` | Project root | Supported for compatibility |
+| `.claude/settings.json` | Project | Project-level behavior settings (committed, shared with team) |
+| `.claude/settings.local.json` | Project | Personal settings override (not committed, stays on your machine) |
 
 > 🎯 **Just getting started?** Use `AGENTS.md` for project instructions. You can explore the other formats later as needed.
+
+### Settings Files (.claude/settings.json)
+
+In addition to instruction files, Copilot reads **settings files** from your project's `.claude/` folder. These control *how* Copilot behaves rather than *what it knows* about your project. Think of instruction files as "here's our coding standards" and settings files as "here's how the tool should behave."
+
+- **`.claude/settings.json`** — Project settings committed to your repo, shared with the whole team.
+- **`.claude/settings.local.json`** — Your personal overrides, not committed (add it to `.gitignore`).
+
+```
+your-project/
+└── .claude/
+    ├── settings.json        # committed — everyone gets these defaults
+    └── settings.local.json  # NOT committed — personal overrides
+```
+
+> 💡 **Tip**: Both files are optional. Start with `AGENTS.md` for instructions, and only add a `settings.json` when you need to tune Copilot's behavior for the whole team.
 
 ### AGENTS.md
 


### PR DESCRIPTION
## What's new in the CLI (past 7 days)

Releases **v1.0.12–v1.0.14** shipped March 26–31, 2026. Two changes are beginner-relevant and were missing from the course:

### 1. `.claude/settings.json` and `.claude/settings.local.json` (v1.0.12)
Copilot CLI now reads these files from the project's `.claude/` folder as additional repo config sources. These are *behavior settings* (how the tool acts) as opposed to *instruction files* (what it knows). The project-level file is committed and shared; the local file is personal and not committed.

### 2. Model picker full-screen view with inline reasoning effort (v1.0.12)
The `/model` command now opens a full-screen picker. Inside it, you can adjust **reasoning effort** with the ← / → arrow keys. The active effort level is shown in the session header (e.g., `claude-sonnet-4.5 (high)`).

---

## What was already covered (no changes needed)
- `/rewind` timeline picker ✓
- `/allow-all [on|off|show]` ✓
- `/rename` auto-generates session name ✓

---

## Sections updated

| Chapter | Change |
|---------|--------|
| **Chapter 04** (`04-agents-custom-instructions/README.md`) | Added `.claude/settings.json` and `.claude/settings.local.json` rows to the Instruction File Formats table; added a new "Settings Files" subsection explaining the two files and their intended use |
| **Chapter 01** (`01-setup-and-first-steps/README.md`) | Updated the "Switching Models" section to describe the full-screen model picker and the ← / → reasoning effort control |

---

## Sources
- [GitHub Copilot CLI v1.0.12 release](https://github.com/github/copilot-cli/releases/tag/v1.0.12)
- [GitHub Copilot CLI v1.0.13 release](https://github.com/github/copilot-cli/releases/tag/v1.0.13)
- [GitHub Copilot CLI v1.0.14 release](https://github.com/github/copilot-cli/releases/tag/v1.0.14)




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/23847375671/agentic_workflow) · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 23847375671, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/23847375671 -->

<!-- gh-aw-workflow-id: course-updater -->