### PR TITLE
[bot] docs: add /share html and /mcp auth commands (v1.0.15)

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -431,7 +431,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/rewind` | Open a timeline picker to roll back to any earlier point in the conversation |
 | `/usage` | Display session usage metrics and statistics |
 | `/session` | Show session info and workspace summary |
-| `/share` | Export session as markdown file or GitHub gist |
+| `/share` | Export session as a markdown file, GitHub gist, or self-contained HTML file |
 
 ### Help and Feedback
 

--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -470,6 +470,10 @@ copilot
 
 > /share gist
 # Creates a GitHub gist with the session
+
+> /share html
+# Exports session as a self-contained interactive HTML file
+# Useful for sharing polished session reports with teammates or saving for reference
 ```
 
 </details>

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -896,6 +896,7 @@ Beyond `/mcp show`, there are several other commands for managing your MCP serve
 | `/mcp enable <server-name>` | Enable a disabled server |
 | `/mcp disable <server-name>` | Temporarily disable a server |
 | `/mcp delete <server-name>` | Remove a server permanently |
+| `/mcp auth <server-name>` | Re-authenticate with an MCP server that uses OAuth (e.g., after switching accounts) |
 
 For most of this course, `/mcp show` is all you need. The other commands become useful as you manage more servers over time.
 


### PR DESCRIPTION
## What's New

Two beginner-relevant features were released in **Copilot CLI v1.0.15** (2026-04-01) that were not yet documented in the course:

### 1. `/share html` — Export sessions as interactive HTML
A new export format joins `/share file` and `/share gist`. The `/share html` command produces a self-contained, interactive HTML file — handy for sharing polished session reports with teammates or saving for future reference without needing GitHub.

### 2. `/mcp auth` — Re-authenticate OAuth MCP servers
A new `/mcp` sub-command for re-authenticating with MCP servers that use OAuth (e.g., after switching GitHub accounts). Previously this wasn't listed in the reference table.

---

## Sections Updated

| File | Change |
|------|--------|
| `01-setup-and-first-steps/README.md` | Updated `/share` entry in the slash commands table to mention the new HTML export option |
| `02-context-conversations/README.md` | Added `/share html` example with a short explanation to the **Share Your Session** snippet |
| `06-mcp-servers/README.md` | Added `/mcp auth <server-name>` row to the **Additional `/mcp` Commands** reference table |

---

## Source

- Release notes: https://github.com/github/copilot-cli/releases/tag/v1.0.15
- Other v1.0.15 changes (model removal, performance fixes, keyboard shortcut tweak) were intentionally omitted as they are not beginner-relevant course content.




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/23899119919/agentic_workflow) · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 23899119919, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/23899119919 -->

<!-- gh-aw-workflow-id: course-updater -->