### PR TITLE
[bot] Add Critic agent and built-in skills documentation (v1.0.17–v1.0.18)

### DIFF
--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -69,6 +69,7 @@ Never used or made an agent? Here's all you need to know to get started for this
 | **Init** | `/init` | Generates project configuration files (instructions, agents) |
 | **Explore** | *Automatic* | Used internally when you ask Copilot to explore or analyze the codebase |
 | **Task** | *Automatic* | Executes commands like tests, builds, lints, and dependency installs |
+| **Critic** | *Automatic (experimental)* | Automatically reviews plans and complex implementations using a complementary model to catch errors early. Available when using Claude models. |
 
 <br>
 

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -277,6 +277,7 @@ Copilot automatically scans these locations for skills:
 |----------|-------|
 | `.github/skills/` | Project-specific (shared with team via git) |
 | `~/.copilot/skills/` | User-specific (your personal skills) |
+| Built into the CLI | Bundled with the CLI itself (e.g., a guide for customizing the Copilot cloud agent environment) |
 
 ### Skill Structure
 


### PR DESCRIPTION
## What's New in v1.0.17–v1.0.18

### New features found

**v1.0.18 (April 4, 2026)**
- **Critic agent** — A new built-in agent that automatically reviews plans and complex implementations using a complementary model to catch errors early. Available in experimental mode for Claude models.
- `preToolUse` hook `permissionDecision 'allow'` — suppresses the tool approval prompt (advanced, not documented here)
- Notification hook event — fires asynchronously on shell/agent completion (advanced)

**v1.0.17 (April 3, 2026)**
- **Built-in skills** — Skills are now bundled with the CLI itself, starting with a guide for customizing the Copilot cloud agent environment. Previously, the course only covered project-level and personal skills.

**Also verified already covered:**
- `/share html` — already documented in Chapter 02 ✅
- `/mcp auth` — already documented in Chapter 06 ✅

### Sections updated

**Chapter 04 — Agents and Custom Instructions**
- Added the **Critic** agent to the built-in agents table, noting it's automatic/experimental and available for Claude models.

**Chapter 05 — Skills System**
- Added a third row to the skill locations table: built-in CLI skills, explaining they ship bundled with the CLI.

### Source announcements

- [v1.0.18 release](https://github.com/github/copilot-cli/releases/tag/v1.0.18)
- [v1.0.17 release](https://github.com/github/copilot-cli/releases/tag/v1.0.17)




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/23978261066/agentic_workflow) · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 23978261066, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/23978261066 -->

<!-- gh-aw-workflow-id: course-updater -->