### PR TITLE
[bot] docs: add built-in skills documentation

### DIFF
--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -66,7 +66,6 @@ Never used or made an agent? Here's all you need to know to get started for this
 |-------|---------------|--------------|
 | **Plan** | `/plan` or `Shift+Tab` (cycle modes) | Creates step-by-step implementation plans before coding |
 | **Code-review** | `/review` | Reviews staged/unstaged changes with focused, actionable feedback |
-| **Critic** | *Automatic* | Reviews plans and complex implementations using a second model to catch errors early (experimental, Claude models only) |
 | **Init** | `/init` | Generates project configuration files (instructions, agents) |
 | **Explore** | *Automatic* | Used internally when you ask Copilot to explore or analyze the codebase |
 | **Task** | *Automatic* | Executes commands like tests, builds, lints, and dependency installs |

--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -66,6 +66,7 @@ Never used or made an agent? Here's all you need to know to get started for this
 |-------|---------------|--------------|
 | **Plan** | `/plan` or `Shift+Tab` (cycle modes) | Creates step-by-step implementation plans before coding |
 | **Code-review** | `/review` | Reviews staged/unstaged changes with focused, actionable feedback |
+| **Critic** | *Automatic* | Reviews plans and complex implementations using a second model to catch errors early (experimental, Claude models only) |
 | **Init** | `/init` | Generates project configuration files (instructions, agents) |
 | **Explore** | *Automatic* | Used internally when you ask Copilot to explore or analyze the codebase |
 | **Task** | *Automatic* | Executes commands like tests, builds, lints, and dependency installs |

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -54,7 +54,9 @@ Learn what skills are, why they matter, and how they differ from agents and MCP.
    copilot
    > /skills list
    ```
-   This shows all skills Copilot can find in your project and personal folders.
+   This shows all skills Copilot can find — including any **built-in skills** that ship with the CLI itself, plus skills from your project and personal folders.
+
+   > 💡 **Built-in skills**: The Copilot CLI now comes with skills pre-installed out of the box. For example, the `customizing-copilot-cloud-agents-environment` skill provides a guide for customizing the Copilot cloud agent's environment. You don't need to create or install anything to use these — just run `/skills list` to see what's available.
 
 2. **Look at a real skill file:** Check out our provided [code-checklist SKILL.md](../.github/skills/code-checklist/SKILL.md) to see the pattern. It's just YAML frontmatter plus markdown instructions.
 

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -54,9 +54,9 @@ Learn what skills are, why they matter, and how they differ from agents and MCP.
    copilot
    > /skills list
    ```
-   This shows all skills Copilot can find — including any **built-in skills** that ship with the CLI itself, plus skills from your project and personal folders.
+   This shows all skills Copilot can find, including any **built-in skills** that ship with the CLI itself, plus skills from your project and personal folders.
 
-   > 💡 **Built-in skills**: The Copilot CLI now comes with skills pre-installed out of the box. For example, the `customizing-copilot-cloud-agents-environment` skill provides a guide for customizing the Copilot cloud agent's environment. You don't need to create or install anything to use these — just run `/skills list` to see what's available.
+   > 💡 **Built-in skills**: The Copilot CLI comes with skills pre-installed out of the box. For example, the `customizing-copilot-cloud-agents-environment` skill provides a guide for customizing the Copilot cloud agent's environment. You don't need to create or install anything to use these. Run `/skills list` to see what's available.
 
 2. **Look at a real skill file:** Check out our provided [code-checklist SKILL.md](../.github/skills/code-checklist/SKILL.md) to see the pattern. It's just YAML frontmatter plus markdown instructions.
 


### PR DESCRIPTION
## What changed

One beginner-relevant update from the Copilot CLI changelog was found and added to the course.

---

### Built-in skills shipped with the CLI (v1.0.17 — April 3, 2026)

> "Built-in skills are now included with the CLI, starting with a guide for customizing Copilot cloud agent's environment"

**Updated:** `05-skills/README.md`

The "New to Skills? Start Here!" section now explains that `/skills list` will also show built-in skills that ship with the CLI (not just project/personal skills). A beginner tip box calls out the `customizing-copilot-cloud-agents-environment` skill as an example, so learners know they already have skills available before creating any.

---

## Already covered (no changes needed)

- `/share html` — already documented in Chapter 02 session management section
- `/mcp auth` — already documented in Chapter 06 additional MCP commands table

---

## Source announcements

- v1.0.17 release: https://github.com/github/copilot-cli/releases/tag/v1.0.17




> Generated by <a href="https://github.com/github/copilot-cli-for-beginners/actions/runs/24030847624/agentic_workflow">Course Updater</a> · <a href="https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests">◷</a>