### PR TITLE
[bot] Add Critic agent to built-in agents documentation (Chapter 04)

### DIFF
--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -69,6 +69,7 @@ Never used or made an agent? Here's all you need to know to get started for this
 | **Init** | `/init` | Generates project configuration files (instructions, agents) |
 | **Explore** | *Automatic* | Used internally when you ask Copilot to explore or analyze the codebase |
 | **Task** | *Automatic* | Executes commands like tests, builds, lints, and dependency installs |
+| **Critic** | *Automatic* | Reviews plans and complex implementations using a second model to catch errors early (experimental, Claude models only) |
 
 <br>
 
@@ -95,6 +96,10 @@ What about the Task Agent? It works behind the scenes to manage and track what i
 |---------|--------------|
 | ✅ **Success** | Brief summary (e.g., "All 247 tests passed", "Build succeeded") |
 | ❌ **Failure** | Full output with stack traces, compiler errors, and detailed logs |
+
+What about the Critic Agent? When you use `/plan`, the Critic agent may automatically kick in to review the plan before you see it. Think of it as a second pair of eyes — it uses a different AI model to double-check the plan for mistakes or gaps before handing it back to you. You don't need to do anything to activate it; just use `/plan` as normal and Copilot handles the rest.
+
+> 💡 **Note**: The Critic agent is currently experimental and works with Claude models. If you don't see it in action, try enabling experimental features in your Copilot settings.
 
 
 > 📚 **Official Documentation**: [GitHub Copilot CLI Agents](https://docs.github.com/copilot/how-tos/use-copilot-agents/use-copilot-cli#use-custom-agents)


### PR DESCRIPTION
## What's New

Checked the Copilot CLI changelog for the past 7 days (releases v1.0.15 through v1.0.20). Most recent additions — `/share html`, `/allow-all [on|off|show]`, `/mcp auth`, `/mcp enable`/`/mcp disable` persisting across sessions, `/rewind` timeline picker, and built-in skills — are already documented in the course.

One new beginner-relevant feature was missing:

**Critic agent** (introduced in [v1.0.18](https://github.com/github/copilot-cli/releases/tag/v1.0.18), April 4 2026):
> New Critic agent automatically reviews plans and complex implementations using a complementary model to catch errors early (available in experimental mode for Claude models)

## What Was Updated

**Chapter 04: Agents and Custom Instructions** (`04-agents-custom-instructions/README.md`):
- Added **Critic** row to the Built-in Agents table
- Added a plain-English explanation of how the Critic agent works alongside `/plan`, written for beginners
- Noted that it is experimental and requires Claude models

## Source

- Release notes: https://github.com/github/copilot-cli/releases/tag/v1.0.18




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/24080090677/agentic_workflow) · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 24080090677, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/24080090677 -->

<!-- gh-aw-workflow-id: course-updater -->