### PR TITLE
[bot] docs(ch06): document new `copilot mcp` command and session-persistent enable/disable

### DIFF
--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -75,7 +75,7 @@ MCP Servers:
 
 > 💡 **Only seeing the GitHub server?** That's expected! If you haven't added any additional MCP servers yet, GitHub is the only one listed. You'll add more in the next section.
 
-> 📚 **Want to see all `/mcp` commands?** There are additional commands for adding, editing, enabling, and deleting servers. See the [full command reference](#-additional-mcp-commands) at the end of this chapter.
+> 📚 **Want to see all MCP management commands?** You can manage servers with `/mcp` slash commands inside chat, or with `copilot mcp` directly from your terminal. See the [full command reference](#-additional-mcp-commands) at the end of this chapter.
 
 <details>
 <summary>🎬 See it in action!</summary>
@@ -883,20 +883,41 @@ If a server is disabled, see the [additional `/mcp` commands](#-additional-mcp-c
 ---
 
 <details>
-<summary>📚 <strong>Additional <code>/mcp</code> Commands</strong> (click to expand)</summary>
+<summary>📚 <strong>Additional MCP Commands</strong> (click to expand)</summary>
 <a id="-additional-mcp-commands"></a>
 
-Beyond `/mcp show`, there are several other commands for managing your MCP servers:
+You can manage MCP servers in two ways: using **slash commands inside a chat session**, or using the **`copilot mcp` command directly in your terminal** (no chat session needed).
+
+### Option 1: Slash commands (inside a chat session)
+
+These work when you're already inside `copilot`:
 
 | Command | What It Does |
 |---------|--------------|
 | `/mcp show` | Show all configured MCP servers and their status |
 | `/mcp add` | Interactive setup for adding a new server |
 | `/mcp edit <server-name>` | Edit an existing server configuration |
-| `/mcp enable <server-name>` | Enable a disabled server |
-| `/mcp disable <server-name>` | Temporarily disable a server |
+| `/mcp enable <server-name>` | Enable a disabled server (persists across sessions) |
+| `/mcp disable <server-name>` | Disable a server (persists across sessions) |
 | `/mcp delete <server-name>` | Remove a server permanently |
 | `/mcp auth <server-name>` | Re-authenticate with an MCP server that uses OAuth (e.g., after switching accounts) |
+
+### Option 2: `copilot mcp` command (from your terminal)
+
+New in v1.0.21, you can also manage MCP servers directly from your terminal without starting a chat session first:
+
+```bash
+# List all configured MCP servers
+copilot mcp list
+
+# Enable a server
+copilot mcp enable filesystem
+
+# Disable a server
+copilot mcp disable context7
+```
+
+> 💡 **When to use which?** Use `/mcp` slash commands when you're already in a chat session. Use `copilot mcp` from the terminal when you want to quickly check or change your server settings before starting a session.
 
 For most of this course, `/mcp show` is all you need. The other commands become useful as you manage more servers over time.
 
@@ -912,7 +933,7 @@ For most of this course, `/mcp show` is all you need. The other commands become 
 2. **GitHub MCP is built-in** - no configuration needed, just `/login`
 3. **Filesystem and Context7** are configured via `~/.copilot/mcp-config.json`
 4. **Multi-server workflows** combine data from multiple sources in a single session
-5. **Check server status** with `/mcp show` (additional commands available for managing servers)
+5. **Manage servers two ways**: use `/mcp` slash commands inside chat, or `copilot mcp` from the terminal
 6. **Custom servers** let you connect any API (optional, covered in the appendix guide)
 
 > 📋 **Quick Reference**: See the [GitHub Copilot CLI command reference](https://docs.github.com/en/copilot/reference/cli-command-reference) for a complete list of commands and shortcuts.

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -904,7 +904,7 @@ These work when you're already inside `copilot`:
 
 ### Option 2: `copilot mcp` command (from your terminal)
 
-New in v1.0.21, you can also manage MCP servers directly from your terminal without starting a chat session first:
+You can also manage MCP servers directly from your terminal without starting a chat session first:
 
 ```bash
 # List all configured MCP servers


### PR DESCRIPTION
## What's new in the Copilot CLI

### v1.0.21 (2026-04-07)
- **New `copilot mcp` top-level command** for managing MCP servers directly from the terminal, without starting a chat session first (e.g., `copilot mcp list`, `copilot mcp enable <name>`, `copilot mcp disable <name>`)

### v1.0.19 (2026-04-06)
- **`/mcp enable` and `/mcp disable` now persist across sessions** — previously these were described as temporary; they now save your choice permanently

---

## What was updated

### Chapter 06: MCP Servers (`06-mcp-servers/README.md`)

1. **Restructured the "Additional MCP Commands" section** into two clearly labelled options:
   - *Option 1*: `/mcp` slash commands (used inside a chat session)
   - *Option 2*: `copilot mcp` command (used directly from the terminal, no chat needed)
   - Includes a usage tip explaining when to use each approach
2. **Updated `/mcp enable` and `/mcp disable` descriptions** to note they persist across sessions (not just temporary)
3. **Updated the Key Takeaways** to reflect the two-approach model
4. **Updated the inline tip** near `/mcp show` to point learners to both approaches

---

## Source announcements

- v1.0.21 release: https://github.com/github/copilot-cli/releases/tag/v1.0.21
- v1.0.19 release: https://github.com/github/copilot-cli/releases/tag/v1.0.19




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/24134097246/agentic_workflow) · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 24134097246, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/24134097246 -->

<!-- gh-aw-workflow-id: course-updater -->