### PR TITLE
[bot] Update course for Copilot CLI v1.0.22–v1.0.23: fix MCP config path and add startup flags

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -272,9 +272,14 @@ Notice how each prompt builds on the previous answer. You're having a conversati
 
 **Best for**: Complex tasks where you want to review the approach before execution. Similar to planning a route before a trip using GPS.
 
-Plan mode helps you create a step-by-step plan before writing any code. Use the `/plan` command or press **Shift+Tab** to cycle into Plan Mode:
+Plan mode helps you create a step-by-step plan before writing any code. Use the `/plan` command, press **Shift+Tab** to cycle into Plan Mode, or use the `--plan` startup flag:
 
 > 💡 **Tip**: **Shift+Tab** cycles between modes: Interactive → Plan → Autopilot. Press it anytime during an interactive session to switch modes without typing a command.
+
+> 💡 **Startup shortcut**: You can launch the CLI directly in Plan mode from your terminal using the `--plan` flag — great when you already know what you want to plan:
+> ```bash
+> copilot --plan "Add a mark as read command to the book app"
+> ```
 
 ```bash
 copilot
@@ -312,7 +317,7 @@ Proceed with implementation? [Y/n]
 
 > 💡 **Want something more complex?** Try: `/plan Add search and filter capabilities to the book app`. Plan mode scales from simple features to full applications.
 
-> 📚 **Autopilot mode**: You may have noticed Shift+Tab cycles through a third mode called **Autopilot**. In autopilot mode, Copilot works through an entire plan without waiting for your input after each step — like handing a task to a colleague and saying "let me know when you're finished." The typical workflow is plan → accept → autopilot, which means you need to be good at writing plans first. Get comfortable with Interactive and Plan modes, then see the [official docs](https://docs.github.com/copilot/concepts/agents/copilot-cli/autopilot) when you're ready.
+> 📚 **Autopilot mode**: You may have noticed Shift+Tab cycles through a third mode called **Autopilot**. In autopilot mode, Copilot works through an entire plan without waiting for your input after each step — like handing a task to a colleague and saying "let me know when you're finished." The typical workflow is plan → accept → autopilot, which means you need to be good at writing plans first. You can also launch directly into autopilot with `copilot --autopilot "Your task here"`. Get comfortable with Interactive and Plan modes first, then see the [official docs](https://docs.github.com/copilot/concepts/agents/copilot-cli/autopilot) when you're ready.
 
 ---
 

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -125,7 +125,9 @@ Now that you've seen MCP in action, let's set up additional servers. This sectio
 
 ## MCP Configuration File
 
-MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.vscode/mcp.json` (project-level, applies to just the current workspace). 
+MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.mcp.json` (project-level, placed in the root of your project).
+
+> ⚠️ **Note**: `.vscode/mcp.json` is no longer supported as an MCP config source. If you have an existing `.vscode/mcp.json`, migrate it to `.mcp.json` in your project root. The CLI will show a migration hint if it detects an old config file.
 
 ```json
 {
@@ -333,7 +335,7 @@ Here's a full `mcp-config.json` with filesystem and Context7 servers:
 }
 ```
 
-Save this as `~/.copilot/mcp-config.json` for global access or `.vscode/mcp.json` for project-specific configuration.
+Save this as `~/.copilot/mcp-config.json` for global access or `.mcp.json` in the project root for project-specific configuration.
 
 ---
 
@@ -840,7 +842,7 @@ Ready to go deeper? Follow the [Custom MCP Server Guide](mcp-custom-server.md) t
 | Mistake | What Happens | Fix |
 |---------|--------------|-----|
 | Not knowing GitHub MCP is built-in | Trying to install/configure it manually | GitHub MCP is included by default. Just try: "List the recent commits in this repo" |
-| Looking for config in wrong location | Can't find or edit MCP settings | User-level config is in `~/.copilot/mcp-config.json`, project-level is `.vscode/mcp.json` |
+| Looking for config in wrong location | Can't find or edit MCP settings | User-level config is in `~/.copilot/mcp-config.json`, project-level is `.mcp.json` in the project root |
 | Invalid JSON in config file | MCP servers fail to load | Use `/mcp show` to check configuration; validate JSON syntax |
 | Forgetting to authenticate MCP servers | "Authentication failed" errors | Some MCPs need separate auth. Check each server's requirements |
 


### PR DESCRIPTION
## What's New in Copilot CLI (last 7 days)

Releases checked: **v1.0.22** (Apr 9) and **v1.0.23** (Apr 10, 2026)

### Beginner-relevant changes found

**v1.0.22** — `.vscode/mcp.json` and `.devcontainer/devcontainer.json` removed as MCP config sources. The CLI now **only reads `.mcp.json`** for project-level MCP configuration. A migration hint appears when `.vscode/mcp.json` is detected.

**v1.0.23** — New `--mode`, `--autopilot`, and `--plan` flags let you start the CLI directly in a specific agent mode without entering interactive mode first (e.g., `copilot --plan "Add a feature"`).

---

## What Was Updated

### Chapter 06: MCP Servers (`06-mcp-servers/README.md`)
- **Fixed outdated config path** (3 places): `.vscode/mcp.json` → `.mcp.json`
- **Added migration note** explaining that `.vscode/mcp.json` is no longer supported, with guidance to move the file to `.mcp.json` in the project root

### Chapter 01: First Steps (`01-setup-and-first-steps/README.md`)
- **Added `--plan` startup flag** tip in the Plan Mode section — beginners can now launch directly into plan mode from the terminal
- **Added `--autopilot` flag mention** in the Autopilot note so learners know they can skip the interactive step

---

## Source Announcements

- v1.0.22 release: https://github.com/github/copilot-cli/releases/tag/v1.0.22
- v1.0.23 release: https://github.com/github/copilot-cli/releases/tag/v1.0.23




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/24342174289/agentic_workflow) · ● 1.2M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 24342174289, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/24342174289 -->

<!-- gh-aw-workflow-id: course-updater -->