### PR TITLE
[bot] Add April 2026 Copilot CLI feature updates to course content

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -320,6 +320,8 @@ Proceed with implementation? [Y/n]
 
 > 📚 **Autopilot mode**: You may have noticed Shift+Tab cycles through a third mode called **Autopilot**. In autopilot mode, Copilot works through an entire plan without waiting for your input after each step — like handing a task to a colleague and saying "let me know when you're finished." The typical workflow is plan → accept → autopilot, which means you need to be good at writing plans first. You can also launch directly into autopilot with `copilot --autopilot`. Get comfortable with Interactive and Plan modes first, then see the [official docs](https://docs.github.com/copilot/concepts/agents/copilot-cli/autopilot) when you're ready.
 
+> 💡 **Start in a specific mode**: You can launch Copilot directly in any mode using flags: `copilot --plan` starts in Plan mode, `copilot --autopilot` starts in Autopilot mode, and `copilot --mode interactive` (or `plan` / `autopilot`) lets you specify the mode explicitly. This is handy when you already know what you want to do.
+
 ---
 
 ### Mode 3: Programmatic Mode
@@ -445,6 +447,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 | Command | What It Does |
 |---------|--------------|
 | `/changelog` | Display changelog for CLI versions |
+| `/env` | Show your loaded environment (instructions, MCP servers, skills, agents, plugins) |
 | `/feedback` | Submit feedback to GitHub |
 | `/help` | Show all available commands |
 | `/theme` | View or set terminal theme |

--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -131,7 +131,7 @@ When reviewing code, always check for:
 - Hardcoded secrets
 ```
 
-> 💡 **Required vs Optional**: The `description` field is required. Other fields like `name`, `tools`, and `model` are optional.
+> 💡 **Required vs Optional**: The `description` field is required. Other fields like `name`, `tools`, `model`, and `skills` are optional.
 
 ## Where to put agent files
 
@@ -507,7 +507,11 @@ You are a Python specialist focused on code quality and best practices.
 | `name` | No | Display name (defaults to filename) |
 | `description` | **Yes** | What the agent does - helps Copilot understand when to suggest it |
 | `tools` | No | List of allowed tools (omit = all tools available). See tool aliases below. |
+| `model` | No | AI model to use for this agent (e.g., `claude-sonnet-4.5`) |
+| `skills` | No | List of skill names to eagerly load into the agent's context at startup |
 | `target` | No | Limit to `vscode` or `github-copilot` only |
+
+> 💡 **The `skills` field**: When you add a `skills` list to an agent, those skills are automatically loaded when the agent starts — you don't need to invoke them manually. This is useful when your agent always needs specific instructions (e.g., a test-writer agent that always loads your `pytest-gen` skill). See [Chapter 05](../05-skills/README.md) for how to create skills.
 
 ### Tool Aliases
 

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -919,6 +919,8 @@ copilot mcp enable filesystem
 copilot mcp disable context7
 ```
 
+> 💡 **Install from the registry**: You can also install MCP servers from the official registry with guided setup. Run `copilot mcp install` and Copilot will walk you through picking a server and configuring it interactively — no manual JSON editing required. This is the easiest way to add a new server you've heard about.
+
 > 💡 **When to use which?** Use `/mcp` slash commands when you're already in a chat session. Use `copilot mcp` from the terminal when you want to quickly check or change your server settings before starting a session.
 
 For most of this course, `/mcp show` is all you need. The other commands become useful as you manage more servers over time.


### PR DESCRIPTION
## What's New

Based on Copilot CLI releases from April 7–14, 2026, the following beginner-relevant features were not yet documented in the course:

### New features found

| Feature | Release | Description |
|---------|---------|-------------|
| `/env` command | v1.0.25 (Apr 13) | Shows all loaded environment details: instructions, MCP servers, skills, agents, and plugins |
| `copilot mcp install` (registry install) | v1.0.25 (Apr 13) | Install MCP servers from the official registry with guided, interactive configuration |
| `--plan` and `--mode` startup flags | v1.0.23 (Apr 10) | Launch Copilot directly in Plan mode or any specific mode without Shift+Tab |
| Agent `skills` frontmatter field | v1.0.22 (Apr 9) | Custom agents can declare skills to eagerly load at startup |

### Course sections updated

**Chapter 01 — Setup and First Steps** (`01-setup-and-first-steps/README.md`)
- Added `/env` to the "Help and Feedback" slash commands table in the Additional Commands reference
- Added a new callout explaining `--plan` and `--mode` startup flags, alongside the existing `--autopilot` note

**Chapter 04 — Agents & Custom Instructions** (`04-agents-custom-instructions/README.md`)
- Added `skills` and `model` rows to the YAML Properties table
- Added a callout explaining when and why to use the `skills` field (auto-loads skills at agent startup)

**Chapter 06 — MCP Servers** (`06-mcp-servers/README.md`)
- Added a callout in the `copilot mcp` terminal commands section explaining `copilot mcp install` for registry-based guided setup

### Source announcements

- [v1.0.25 release](https://github.com/github/copilot-cli/releases/tag/v1.0.25) — `/env` command, MCP registry install
- [v1.0.23 release](https://github.com/github/copilot-cli/releases/tag/v1.0.23) — `--mode`, `--plan`, `--autopilot` flags
- [v1.0.22 release](https://github.com/github/copilot-cli/releases/tag/v1.0.22) — Agent `skills` field

### What was skipped (not beginner-relevant)

- Plugin hooks receiving `PLUGIN_ROOT` env vars (v1.0.26-0, prerelease)
- OpenTelemetry/monitoring topic (`copilot help monitoring`, v1.0.20)
- Azure OpenAI BYOK configuration changes (advanced/enterprise)
- ACP client MCP server provisioning (advanced)
- `--remote` / `/remote` — already documented in ch01
- `.vscode/mcp.json` deprecation — already documented in ch06




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/24397627427/agentic_workflow) · ● 1M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 24397627427, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/24397627427 -->

<!-- gh-aw-workflow-id: course-updater -->