### PR TITLE
[bot] Add /ask, /env, MCP registry install, and plugin marketplace update commands

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -363,16 +363,19 @@ copilot --allow-all -p "Review @myfile.py for issues"
 
 ## Essential Slash Commands
 
-These commands work in interactive mode. **Start with just these six** - they cover 90% of daily use:
+These commands work in interactive mode. **Start with just these seven** - they cover 90% of daily use:
 
 | Command | What It Does | When to Use |
 |---------|--------------|-------------|
+| `/ask` | Ask a quick question without it affecting your conversation history | When you want a quick answer without derailing your current task |
 | `/clear` | Clear conversation and start fresh | When switching topics |
 | `/help` | Show all available commands | When you forget a command |
 | `/model` | Show or switch AI model | When you want to change the AI model |
 | `/plan` | Plan your work out before coding | For more complex features |
 | `/research` | Deep research using GitHub and web sources | When you need to investigate a topic before coding |
 | `/exit` | End the session | When you're done |
+
+> 💡 **`/ask` vs regular chat**: Normally every message you send becomes part of the ongoing conversation and affects future responses. `/ask` is an "off the record" shortcut — perfect for quick one-off questions like `/ask What does YAML mean?` without polluting your session context.
 
 That's it for getting started! As you become comfortable, you can explore additional commands.
 
@@ -388,9 +391,12 @@ That's it for getting started! As you become comfortable, you can explore additi
 | Command | What It Does |
 |---------|--------------|
 | `/agent` | Browse and select from available agents |
+| `/env` | Show loaded environment details — what instructions, MCP servers, skills, agents, and plugins are active |
 | `/init` | Initialize Copilot instructions for your repository |
 | `/mcp` | Manage MCP server configuration |
 | `/skills` | Manage skills for enhanced capabilities |
+
+> 💡 **`/env` tip**: Use `/env` whenever you want to confirm that Copilot has picked up your custom agents, skills, or MCP servers. It's a great first step if something isn't working as expected.
 
 > 💡 Agents are covered in [Chapter 04](../04-agents-custom-instructions/README.md), skills are covered in [Chapter 05](../05-skills/README.md), and MCP servers are covered in [Chapter 06](../06-mcp-servers/README.md).
 
@@ -653,7 +659,7 @@ The examples used `/plan` for a search feature and `-p` for batch reviews. Now t
 1. **Interactive mode** is for exploration and iteration - context carries forward. It's like having a conversation with someone who remembers what you've said up to that point.
 2. **Plan mode** is normally for more involved tasks. Review before implementation.
 3. **Programmatic mode** is for automation. No interaction needed.
-4. **Essential commands** (`/help`, `/clear`, `/plan`, `/research`, `/model`, `/exit`) cover most daily use.
+4. **Essential commands** (`/ask`, `/help`, `/clear`, `/plan`, `/research`, `/model`, `/exit`) cover most daily use.
 
 > 📋 **Quick Reference**: See the [GitHub Copilot CLI command reference](https://docs.github.com/en/copilot/reference/cli-command-reference) for a complete list of commands and shortcuts.
 

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -396,8 +396,6 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/mcp` | Manage MCP server configuration |
 | `/skills` | Manage skills for enhanced capabilities |
 
-> 💡 **`/env` tip**: Use `/env` whenever you want to confirm that Copilot has picked up your custom agents, skills, or MCP servers. It's a great first step if something isn't working as expected.
-
 > 💡 Agents are covered in [Chapter 04](../04-agents-custom-instructions/README.md), skills are covered in [Chapter 05](../05-skills/README.md), and MCP servers are covered in [Chapter 06](../06-mcp-servers/README.md).
 
 ### Models and Subagents

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -363,7 +363,7 @@ copilot --allow-all -p "Review @myfile.py for issues"
 
 ## Essential Slash Commands
 
-These commands work in interactive mode. **Start with just these seven** - they cover 90% of daily use:
+These commands work in interactive mode. **Start with just these** - they cover 90% of daily use:
 
 | Command | What It Does | When to Use |
 |---------|--------------|-------------|

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -363,7 +363,7 @@ copilot --allow-all -p "Review @myfile.py for issues"
 
 ## Essential Slash Commands
 
-These commands work in interactive mode. **Start with just these** - they cover 90% of daily use:
+These commands are great to learn initially as you're getting started with Copilot CLI:
 
 | Command | What It Does | When to Use |
 |---------|--------------|-------------|

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -546,6 +546,14 @@ copilot
 # Install a plugin from the marketplace
 ```
 
+To keep your local plugin catalog current, refresh it with:
+
+```bash
+copilot plugin marketplace update
+```
+
+> 💡 **When to run this**: If you notice that new plugins aren't appearing in `/plugin marketplace`, running this command fetches the latest catalog from the marketplace server.
+
 Plugins can bundle multiple capabilities together - a single plugin might include related skills, agents, and MCP server configurations that work together.
 
 ### Community Skill Repositories

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -552,9 +552,7 @@ To keep your local plugin catalog current, refresh it with:
 copilot plugin marketplace update
 ```
 
-> 💡 **When to run this**: If you notice that new plugins aren't appearing in `/plugin marketplace`, running this command fetches the latest catalog from the marketplace server.
-
-Plugins can bundle multiple capabilities together - a single plugin might include related skills, agents, and MCP server configurations that work together.
+Plugins can bundle multiple capabilities together. A single plugin might include related skills, agents, and MCP server configurations that work together.
 
 ### Community Skill Repositories
 

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -119,13 +119,29 @@ MCP makes Copilot aware of your actual development environment.
 
 <img src="images/configuring-mcp-servers.png" alt="Hands adjusting knobs and sliders on a professional audio mixing board representing MCP server configuration" width="800"/>
 
-Now that you've seen MCP in action, let's set up additional servers. This section covers the configuration file format and how to add new servers.
+Now that you've seen MCP in action, let's set up additional servers. You can add servers in two ways: **from the built-in registry** (easiest — guided setup right in the CLI) or by **editing the config file** manually (more flexible). Start with the registry option if you're not sure which to choose.
+
+---
+
+## Installing MCP Servers from the Registry
+
+The CLI has a built-in MCP server registry that lets you discover and install popular servers with a guided setup — no JSON editing required.
+
+```bash
+copilot
+
+> /mcp install
+```
+
+Copilot opens an interactive picker showing available servers. Select one, and the CLI walks you through any required configuration (API keys, paths, etc.) and adds it to your config automatically.
+
+> 💡 **Why use the registry?** It's the easiest way to get started — you don't need to know the npm package name, command arguments, or JSON structure. The CLI handles all of that for you.
 
 ---
 
 ## MCP Configuration File
 
-MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.mcp.json` (project-level, placed in the root of your project).
+MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.mcp.json` (project-level, placed in the root of your project). If you used `/mcp install` above, the CLI already created or updated this file for you — but it's useful to understand the format for advanced customization.
 
 > ⚠️ **Note**: `.vscode/mcp.json` is no longer supported as an MCP config source. If you have an existing `.vscode/mcp.json`, migrate it to `.mcp.json` in your project root. The CLI will show a migration hint if it detects an old config file.
 

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -141,7 +141,7 @@ Copilot opens an interactive picker showing available servers. Select one, and t
 
 ## MCP Configuration File
 
-MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.mcp.json` (project-level, placed in the root of your project). If you used `/mcp search` above, the CLI already created or updated this file for you — but it's useful to understand the format for customization.
+MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.mcp.json` (project-level, placed in the root of your project). If you used `/mcp search` above, the CLI already created or updated this file for you, but it's useful to understand the format for customization.
 
 > ⚠️ **Note**: `.vscode/mcp.json` is no longer supported as an MCP config source. If you have an existing `.vscode/mcp.json`, migrate it to `.mcp.json` in your project root. The CLI will show a migration hint if it detects an old config file.
 

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -130,7 +130,7 @@ The CLI has a built-in MCP server registry that lets you discover and install po
 ```bash
 copilot
 
-> /mcp install
+> /mcp search
 ```
 
 Copilot opens an interactive picker showing available servers. Select one, and the CLI walks you through any required configuration (API keys, paths, etc.) and adds it to your config automatically.
@@ -141,7 +141,7 @@ Copilot opens an interactive picker showing available servers. Select one, and t
 
 ## MCP Configuration File
 
-MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.mcp.json` (project-level, placed in the root of your project). If you used `/mcp install` above, the CLI already created or updated this file for you — but it's useful to understand the format for advanced customization.
+MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.mcp.json` (project-level, placed in the root of your project). If you used `/mcp search` above, the CLI already created or updated this file for you — but it's useful to understand the format for advanced customization.
 
 > ⚠️ **Note**: `.vscode/mcp.json` is no longer supported as an MCP config source. If you have an existing `.vscode/mcp.json`, migrate it to `.mcp.json` in your project root. The CLI will show a migration hint if it detects an old config file.
 

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -141,7 +141,7 @@ Copilot opens an interactive picker showing available servers. Select one, and t
 
 ## MCP Configuration File
 
-MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.mcp.json` (project-level, placed in the root of your project). If you used `/mcp search` above, the CLI already created or updated this file for you — but it's useful to understand the format for advanced customization.
+MCP servers are configured in `~/.copilot/mcp-config.json` (user-level, applies to all projects) or `.mcp.json` (project-level, placed in the root of your project). If you used `/mcp search` above, the CLI already created or updated this file for you — but it's useful to understand the format for customization.
 
 > ⚠️ **Note**: `.vscode/mcp.json` is no longer supported as an MCP config source. If you have an existing `.vscode/mcp.json`, migrate it to `.mcp.json` in your project root. The CLI will show a migration hint if it detects an old config file.
 


### PR DESCRIPTION
## What changed

This PR documents four beginner-relevant features from Copilot CLI releases **v1.0.25**, **v1.0.26**, and **v1.0.27** (April 13–15, 2026).

---

### New features found

| Feature | Release | What it does |
|---------|---------|-------------|
| `/ask` command | v1.0.27 | Ask a quick question without it affecting your conversation history |
| `/env` command | v1.0.25 | Shows all loaded environment details — instructions, MCP servers, skills, agents, and plugins |
| MCP registry install (`/mcp install`) | v1.0.25 | Install MCP servers from a built-in registry with guided configuration — no JSON editing required |
| `copilot plugin marketplace update` | v1.0.27 | Refreshes local plugin catalogs so new plugins show up in `/plugin marketplace` |

Features excluded as too advanced for beginners: OpenTelemetry monitoring, ACP client MCP providers, Anthropic BYOM image data, enterprise login improvements, plugin hook env vars.

---

### Sections updated

**`01-setup-and-first-steps/README.md`**
- Added `/ask` to the **Essential Slash Commands** table (with an explanation of how it differs from regular chat)
- Added `/env` to the **Agent Environment** section of Additional Commands, with a troubleshooting tip
- Updated the Key Takeaways list to include `/ask`

**`05-skills/README.md`**
- Added `copilot plugin marketplace update` command to the Plugins section with a usage note

**`06-mcp-servers/README.md`**
- Added a new **Installing MCP Servers from the Registry** section before the manual JSON config section, positioning `/mcp install` as the easiest starting point for beginners
- Updated the MCP Configuration File intro to note that the registry install handles the JSON automatically

---

### Source announcements

- [v1.0.27 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.27) — `/ask` command, `copilot plugin marketplace update`, status bar hints
- [v1.0.26 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.26) — instruction file deduplication, remote control rename
- [v1.0.25 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.25) — `/env` command, MCP registry install, `/remote` command




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/24453186710/agentic_workflow) · ● 1.2M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 24453186710, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/24453186710 -->

<!-- gh-aw-workflow-id: course-updater -->