### PR TITLE
[bot] Update course for Copilot CLI v1.0.22–v1.0.28 changes

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -569,7 +569,7 @@ Start a remote session with the `--remote` flag:
 copilot --remote
 ```
 
-Copilot CLI will display a link and provide access to a QR code. Open the link on your phone or in a desktop browser tab to watch the session in real time, send follow-up prompts, review plans, and steer the agent remotely. Sessions are user-specific so you can only access your own Copilot CLI sessions.
+Copilot CLI will display a link and provide access to a QR code. Open the link on your phone or in a desktop browser tab to watch the session in real time, send follow-up prompts, review plans, and remotely control the agent. Sessions are user-specific so you can only access your own Copilot CLI sessions.
 
 You can also enable remote access from inside an active session at any time:
 

--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -843,6 +843,8 @@ copilot --add-dir /path/to/directory
 > /add-dir /path/to/directory
 ```
 
+> 💡 **Relative paths work too**: You can use relative paths like `./src` or `../sibling-folder` — the CLI resolves them to absolute paths automatically. This is handy when you're already in the right parent directory.
+
 **Context fills up too quickly**:
 - Be more specific with file references
 - Use `/clear` between different topics

--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -131,7 +131,7 @@ When reviewing code, always check for:
 - Hardcoded secrets
 ```
 
-> 💡 **Required vs Optional**: The `description` field is required. Other fields like `name`, `tools`, and `model` are optional.
+> 💡 **Required vs Optional**: The `description` field is required. Other fields like `name`, `tools`, `skills`, and `model` are optional.
 
 ## Where to put agent files
 
@@ -508,6 +508,7 @@ You are a Python specialist focused on code quality and best practices.
 | `description` | **Yes** | What the agent does - helps Copilot understand when to suggest it |
 | `tools` | No | List of allowed tools (omit = all tools available). See tool aliases below. |
 | `target` | No | Limit to `vscode` or `github-copilot` only |
+| `skills` | No | List of skill names to load into agent context automatically at startup |
 
 ### Tool Aliases
 
@@ -521,6 +522,8 @@ Use these names in the `tools` list:
 > 📖 **Official docs**: [Custom agents configuration](https://docs.github.com/copilot/reference/custom-agents-configuration)
 >
 > ⚠️ **VS Code Only**: The `model` property (for selecting AI models) works in VS Code but is not supported in GitHub Copilot CLI. You can safely include it for cross-platform agent files. GitHub Copilot CLI will ignore it.
+
+> 💡 **Combining agents and skills**: The `skills` field lets an agent pre-load specific skills into its context at startup. For example, if your agent always needs the `code-checklist` skill, add `skills: [code-checklist]` to its frontmatter so it's automatically available without needing to invoke it separately. You'll learn more about creating skills in [Chapter 05](../05-skills/README.md).
 
 ### More Agent Templates
 


### PR DESCRIPTION
## What was found

Reviewing GitHub Copilot CLI releases from **April 9–16, 2026** (v1.0.22 through v1.0.28), three beginner-relevant changes were identified that were not yet reflected in the course content on `main`:

1. **v1.0.26** — "Steering" renamed to "remote control" in `--remote`/`/remote` help text and documentation
2. **v1.0.25** — `/add-dir` now accepts relative paths (e.g. `./src`, `../sibling`) in addition to absolute paths
3. **v1.0.22** — Custom agents can now declare a `skills` field to eagerly load skill content into agent context at startup

> Note: Other recent additions (`/ask`, `/env`, `--plan`, `--autopilot`, `/remote`, `.mcp.json` migration, `plugin marketplace update`, MCP from registry) were already present in the `main` branch.

## What was updated

### Chapter 01: First Steps (`01-setup-and-first-steps/README.md`)
- Updated the remote sessions tip to use the current "remote control" terminology instead of the older "steer" wording (aligns with v1.0.26 rename)

### Chapter 02: Context and Conversations (`02-context-conversations/README.md`)
- Added a callout in the `/add-dir` troubleshooting section noting that relative paths (`./src`, `../sibling-folder`) are now supported and resolved automatically

### Chapter 04: Agents and Custom Instructions (`04-agents-custom-instructions/README.md`)
- Added `skills` as an optional property in the agent frontmatter reference table
- Updated the "Required vs Optional" inline note to include `skills`
- Added a tip explaining how the `skills` field lets agents pre-load specific skills into context at startup (bridges the agents-and-skills concepts across Ch04 and Ch05)

## Source announcements

- [v1.0.28 release](https://github.com/github/copilot-cli/releases/tag/v1.0.28) — 2026-04-16
- [v1.0.27 release](https://github.com/github/copilot-cli/releases/tag/v1.0.27) — 2026-04-15
- [v1.0.26 release](https://github.com/github/copilot-cli/releases/tag/v1.0.26) — 2026-04-14 (steering → remote control rename)
- [v1.0.25 release](https://github.com/github/copilot-cli/releases/tag/v1.0.25) — 2026-04-13 (`/add-dir` relative paths)
- [v1.0.22 release](https://github.com/github/copilot-cli/releases/tag/v1.0.22) — 2026-04-09 (custom agent `skills` field)




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 15 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [https://github.com/github/copilot-cli-for-beginners/commit/9fcf0685768cb64134dc081c3995df240808ccf5](https://github.com/github/copilot-cli-for-beginners/commit/9fcf0685768cb64134dc081c3995df240808ccf5) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/d1c40ac682804fe40d595fe71258fdb6587c0531](https://github.com/github/copilot-cli-for-beginners/commit/d1c40ac682804fe40d595fe71258fdb6587c0531) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/879d4c6c7c1be76408e76767beed30a696f80b3b](https://github.com/github/copilot-cli-for-beginners/commit/879d4c6c7c1be76408e76767beed30a696f80b3b) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/78e4ace387849b631bd425c31d314eccc5df2e04](https://github.com/github/copilot-cli-for-beginners/commit/78e4ace387849b631bd425c31d314eccc5df2e04) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/18a1ce0abb72f85586a94fa32b5e8260d3579c35](https://github.com/github/copilot-cli-for-beginners/commit/18a1ce0abb72f85586a94fa32b5e8260d3579c35) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/df00a833561fa5c302384ca6159ae8a679687195](https://github.com/github/copilot-cli-for-beginners/commit/df00a833561fa5c302384ca6159ae8a679687195) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/17791266afdd2119a5f8b0ec598c1eb4145613f1](https://github.com/github/copilot-cli-for-beginners/commit/17791266afdd2119a5f8b0ec598c1eb4145613f1) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/29a54cb626f8534010d94652c0de672682a4df5a](https://github.com/github/copilot-cli-for-beginners/commit/29a54cb626f8534010d94652c0de672682a4df5a) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/de273555a5f5eca483196d0b0290c913680e800b](https://github.com/github/copilot-cli-for-beginners/commit/de273555a5f5eca483196d0b0290c913680e800b) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/594869e06d8a8d7c4bcee8273143af764ba7e0ff](https://github.com/github/copilot-cli-for-beginners/commit/594869e06d8a8d7c4bcee8273143af764ba7e0ff) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/079d3e91eada90cf65cbc81f1a34a2036d1a0dc1](https://github.com/github/copilot-cli-for-beginners/commit/079d3e91eada90cf65cbc81f1a34a2036d1a0dc1) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/a9e32fe1746a8f09f4dcd9a43a7d7beced7dd2c1](https://github.com/github/copilot-cli-for-beginners/commit/a9e32fe1746a8f09f4dcd9a43a7d7beced7dd2c1) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/8b037c72c5e9386cba34850b370831cd4e1c0d3a](https://github.com/github/copilot-cli-for-beginners/commit/8b037c72c5e9386cba34850b370831cd4e1c0d3a) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/46af54c7b8b6ee92067540bc189e2e5a36d8b021](https://github.com/github/copilot-cli-for-beginners/commit/46af54c7b8b6ee92067540bc189e2e5a36d8b021) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/github/copilot-cli-for-beginners/commit/bfa047c4368ad08a1bbe820781504b9bae537096](https://github.com/github/copilot-cli-for-beginners/commit/bfa047c4368ad08a1bbe820781504b9bae537096) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/24508939279/agentic_workflow) · ● 1.6M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 24508939279, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/24508939279 -->

<!-- gh-aw-workflow-id: course-updater -->