### PR TITLE
[bot] Add auto model selection, document file attachment, and new slash command aliases

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -433,16 +433,16 @@ That's it for getting started! As you become comfortable, you can explore additi
 
 | Command | What It Does |
 |---------|--------------|
-| `/clear` | Abandons the current session (no history saved) and starts a fresh conversation |
+| `/clear` (or `/reset`) | Abandons the current session (no history saved) and starts a fresh conversation |
 | `/compact` | Summarize conversation to reduce context usage |
 | `/context` | Show context window token usage and visualization |
 | `/new` | Ends the current session (saving it to history for search/resume) and starts a fresh conversation. |
-| `/resume` | Switch to a different session (optionally specify session ID) |
+| `/resume` (or `/continue`) | Switch to a different session (optionally specify session ID) |
 | `/rename` | Rename the current session (omit the name to auto-generate one) |
 | `/rewind` | Open a timeline picker to roll back to any earlier point in the conversation |
 | `/usage` | Display session usage metrics and statistics |
 | `/session` | Show session info and workspace summary |
-| `/share` | Export session as a markdown file, GitHub gist, or self-contained HTML file |
+| `/share` (or `/export`) | Export session as a markdown file, GitHub gist, or self-contained HTML file |
 
 ### Display
 
@@ -455,8 +455,8 @@ That's it for getting started! As you become comfortable, you can explore additi
 
 | Command | What It Does |
 |---------|--------------|
-| `/changelog` | Display changelog for CLI versions |
-| `/feedback` | Submit feedback to GitHub |
+| `/changelog` (or `/release-notes`) | Display changelog for CLI versions |
+| `/feedback` (or `/bug`) | Submit feedback or report a bug to GitHub |
 | `/help` | Show all available commands |
 
 ### Quick Shell Commands
@@ -485,6 +485,8 @@ copilot
 ```
 
 > 💡 **Tip**: Some models cost more "premium requests" than others. Models marked **1x** (like Claude Sonnet 4.5) are a great default. They're capable and efficient. Higher-multiplier models use your premium request quota faster, so save those for when you really need them.
+
+> 💡 **New: `auto` model**: You can select `auto` from the `/model` picker to let Copilot automatically choose the best available model for each session. This is a great starting option if you're unsure which model to pick — Copilot will adapt based on what's available to you.
 
 </details>
 

--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -427,6 +427,7 @@ These topics build on the essentials above. **Pick what interests you, or skip a
 | Token limits and `/compact` | [Understanding Context Windows](#understanding-context-windows) |
 | How to pick the right files to reference | [Choosing What to Reference](#choosing-what-to-reference) |
 | Analyzing screenshots and mockups | [Working with Images](#working-with-images) |
+| Attaching PDFs and other documents | [Attaching Document Files](#attaching-document-files) |
 
 <details>
 <summary><strong>Additional @ Patterns & Session Commands</strong></summary>
@@ -687,6 +688,22 @@ copilot
 
 > 📖 **Learn more**: See [Additional Context Features](../appendices/additional-context.md#working-with-images) for supported formats, practical use cases, and tips for combining images with code.
 
+<a id="attaching-document-files"></a>
+
+### Attaching Document Files
+
+You can also attach supported document files (such as PDFs) to your prompts using the same `@` syntax. This is handy for providing specs, design documents, or reference material that Copilot can read and reason about alongside your code.
+
+```bash
+copilot
+
+> @requirements.pdf Summarize the key requirements and check if @samples/book-app-project/book_app.py covers them
+
+> @design-doc.pdf What features are described here that are missing from @samples/book-app-project/
+```
+
+> 💡 **Tip**: Document attachment works great for onboarding — paste a spec or design doc and ask Copilot to map it to your existing code.
+
 </details>
 
 ---
@@ -856,12 +873,13 @@ copilot --add-dir /path/to/directory
 
 ## 🔑 Key Takeaways
 
-1. **`@` syntax** gives Copilot CLI context about files, directories, and images
+1. **`@` syntax** gives Copilot CLI context about files, directories, images, and documents
 2. **Multi-turn conversations** build on each other as context accumulates
 3. **Sessions auto-save**: use `--continue` or `--resume` to pick up where you left off
 4. **Context windows** have limits: manage them with `/clear`, `/compact`, `/context`, `/new`, and `/rewind`
 5. **Permission flags** (`--add-dir`, `--allow-all`) control multi-directory access. Use them wisely!
 6. **Image references** (`@screenshot.png`) help debug UI issues visually
+7. **Document files** (like PDFs) can be attached with `@` to give Copilot specs, designs, or reference material
 
 > 📚 **Official Documentation**: [Use Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli/use-copilot-cli) for the complete reference on context, sessions, and working with files.
 


### PR DESCRIPTION
## What's New

Updates based on Copilot CLI releases **v1.0.32** (April 17) and **v1.0.33** (April 20), targeting beginner-relevant features.

### New features found

| Feature | Release | Relevant for beginners? |
|---------|---------|------------------------|
| `auto` model selection — Copilot picks the best model automatically | v1.0.32 | ✅ Yes — removes decision fatigue for new users |
| Attach supported document files (PDFs etc.) to prompts via `@` | v1.0.32 | ✅ Yes — extends the `@` context learners already know |
| `/reset` alias for `/clear`, `/continue` alias for `/resume`, `/export` alias for `/share` | v1.0.33 | ✅ Yes — common alternate names beginners might try |
| `/release-notes` alias for `/changelog`, `/bug` alias for `/feedback` | v1.0.33 | ✅ Yes — more intuitive names for existing commands |
| Usage warnings at 50% and 95% (in addition to existing 75%/90%) | v1.0.33 | i️ UX improvement only — no doc change needed |
| Slash command picker suggests similar commands on typos | v1.0.33 | i️ UX improvement only — no doc change needed |
| Claude Opus 4.7 model added | v1.0.29 | i️ Model availability — no doc change needed |

### Sections updated

**`01-setup-and-first-steps/README.md`** (Additional Commands section):
- **Session table**: Added `/reset` alias for `/clear`, `/continue` alias for `/resume`, and `/export` alias for `/share`
- **Help and Feedback table**: Added `/release-notes` alias for `/changelog` and `/bug` alias for `/feedback`
- **Switching Models section**: Added a tip about the new `auto` model option

**`02-context-conversations/README.md`**:
- Added a new **Attaching Document Files** subsection with beginner-friendly examples showing how to use `@` to attach PDFs/docs alongside code
- Added document files to the optional topics navigation table
- Updated Key Takeaways to mention document file support

### Source announcements

- v1.0.32 release: https://github.com/github/copilot-cli/releases/tag/v1.0.32
- v1.0.33 release: https://github.com/github/copilot-cli/releases/tag/v1.0.33




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/24721102723/agentic_workflow) · ● 1.8M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 24721102723, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/24721102723 -->

<!-- gh-aw-workflow-id: course-updater -->