### PR TITLE
Add commit message generation instructions

### DIFF
--- a/03-development-workflows/README.md
+++ b/03-development-workflows/README.md
@@ -724,7 +724,7 @@ copilot
 > Users report: 'Finding books by author name doesn't work for partial names'
 > @samples/book-app-project/books.py Analyze and identify the likely cause
 
-# 2. Debug the issue (continuing in same session)
+# 2. Debug the issue and fix (continuing in same session)
 > Based on the analysis, show me the find_by_author function and explain the issue
 
 > Fix the find_by_author function to handle partial name matches
@@ -736,15 +736,23 @@ copilot
 > - Case-insensitive matching
 > - Author name not found
 
-# You can generate a commit message in interactive mode or programmatic mode
-# Exit the interactive session and do it using `copilot -p`
+# Exit the interactive session
 
 > /exit
 
-# 4. Generate commit message
+# 4. Run git add
+
+# Stage the changes so git diff --staged has something to work with
+git add .
+
+# 5. Generate commit message
 copilot -p "Generate commit message for: $(git diff --staged)"
 
-# Output: "fix(books): support partial author name search"
+# Example Output: "fix(books): support partial author name search"
+
+# 6. Commit changes (optional)
+
+git commit -m "<paste generated message>"
 ```
 
 ### Bug Fix Workflow Summary
@@ -752,10 +760,11 @@ copilot -p "Generate commit message for: $(git diff --staged)"
 | Step | Action | Copilot Command |
 |------|--------|-----------------|
 | 1 | Understand the bug | `> [describe bug] @relevant-file.py Analyze the likely cause` |
-| 2 | Get detailed analysis | `> Show me the function and explain the issue` |
-| 3 | Implement the fix | `> Fix the [specific issue]` |
-| 4 | Generate tests | `> Generate tests for [specific scenarios]` |
-| 5 | Commit | `copilot -p "Generate commit message for: $(git diff --staged)"` |
+| 2 | Analysis and fix | `> Show me the function and fix the issue` |
+| 3 | Generate tests | `> Generate tests for [specific scenarios]` |
+| 4 | Stage changes | `git add .` |
+| 5 | Generate commit message | `copilot -p "Generate commit message for: $(git diff --staged)"` |
+| 6 | Commit changes| `git commit -m "<paste generated message>"` |
 
 ---
 

--- a/03-development-workflows/README.md
+++ b/03-development-workflows/README.md
@@ -736,6 +736,11 @@ copilot
 > - Case-insensitive matching
 > - Author name not found
 
+# You can generate a commit message in interactive mode or programmatic mode
+# Exit the interactive session and do it using `copilot -p`
+
+> /exit
+
 # 4. Generate commit message
 copilot -p "Generate commit message for: $(git diff --staged)"
 


### PR DESCRIPTION
This pull request updates the documentation for the `copilot` tool to clarify how to generate commit messages in both interactive and programmatic modes. It adds an example of exiting the interactive session and demonstrates using the `copilot -p` command to generate a commit message from staged changes.Added instructions for generating commit messages in interactive and programmatic modes.