### PR TITLE
chore: switch course-updater to weekly on Monday and add duplicate PR prevention

### DIFF
--- a/.github/workflows/course-updater.lock.yml
+++ b/.github/workflows/course-updater.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"392faada2ff3018cb510c08e4ccc127f642791025fab2c2965f4b8c100b17539","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7b67212e2086070d4622e72ea2514453d5a2ba0093a2ba686ecb4ba55a530f59","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Daily check for new GitHub Copilot CLI features and updates. Opens a PR if the course content needs updating.
+# Weekly check (Mondays) for new GitHub Copilot CLI features and updates. Opens a PR if the course content needs updating.
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -42,8 +42,8 @@
 name: "Course Updater"
 "on":
   schedule:
-  - cron: "38 11 * * *"
-    # Friendly format: daily (scattered)
+  - cron: "38 11 * * 1"
+    # Friendly format: weekly on monday (scattered)
   workflow_dispatch:
     inputs:
       aw_context:
@@ -158,19 +158,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_96aea1fc2c8492ca_EOF'
+          cat << 'GH_AW_PROMPT_da18aaba3a78fe8f_EOF'
           <system>
-          GH_AW_PROMPT_96aea1fc2c8492ca_EOF
+          GH_AW_PROMPT_da18aaba3a78fe8f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_96aea1fc2c8492ca_EOF'
+          cat << 'GH_AW_PROMPT_da18aaba3a78fe8f_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_96aea1fc2c8492ca_EOF
+          GH_AW_PROMPT_da18aaba3a78fe8f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_96aea1fc2c8492ca_EOF'
+          cat << 'GH_AW_PROMPT_da18aaba3a78fe8f_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -200,12 +200,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_96aea1fc2c8492ca_EOF
+          GH_AW_PROMPT_da18aaba3a78fe8f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_96aea1fc2c8492ca_EOF'
+          cat << 'GH_AW_PROMPT_da18aaba3a78fe8f_EOF'
           </system>
           {{#runtime-import .github/workflows/course-updater.md}}
-          GH_AW_PROMPT_96aea1fc2c8492ca_EOF
+          GH_AW_PROMPT_da18aaba3a78fe8f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -369,9 +369,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_40c7340e920eba23_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8267a15d6774039b_EOF'
           {"create_pull_request":{"base_branch":"main","labels":["automated-update","copilot-cli-updates"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[bot] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_40c7340e920eba23_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8267a15d6774039b_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -569,7 +569,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_8cd7d8bd3e51245c_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_1fee4f046759e415_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -610,7 +610,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8cd7d8bd3e51245c_EOF
+          GH_AW_MCP_CONFIG_1fee4f046759e415_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1031,7 +1031,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           WORKFLOW_NAME: "Course Updater"
-          WORKFLOW_DESCRIPTION: "Daily check for new GitHub Copilot CLI features and updates. Opens a PR if the course content needs updating."
+          WORKFLOW_DESCRIPTION: "Weekly check (Mondays) for new GitHub Copilot CLI features and updates. Opens a PR if the course content needs updating."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |

--- a/.github/workflows/course-updater.md
+++ b/.github/workflows/course-updater.md
@@ -1,8 +1,8 @@
 ---
 name: "Course Updater"
-description: "Daily check for new GitHub Copilot CLI features and updates. Opens a PR if the course content needs updating."
+description: "Weekly check (Mondays) for new GitHub Copilot CLI features and updates. Opens a PR if the course content needs updating."
 on:
-  schedule: daily
+  schedule: weekly on monday
   workflow_dispatch:
 tools:
   bash: ["curl", "gh"]
@@ -37,11 +37,15 @@ Look for:
 - Significant changes to existing features (renames, deprecations)
 - New customization options (e.g. instructions, agents, skills, MCP, plugins)
 
-## Step 2 — Compare against the current course content and existing PRs
+## Step 2 — Check for existing open PRs to avoid duplicates
+
+Before doing any content comparison, list all open pull requests in this repo that have the `automated-update` or `copilot-cli-updates` labels. Read their titles and descriptions to understand which features or changes each PR already covers. Build a list of features that are **already addressed** by existing PRs — you must exclude those features from any updates you propose later. If every feature you found in Step 1 is already covered by an open PR, stop here and report that no new updates are needed.
+
+## Step 3 — Compare against the current course content
 
 This course targets beginners, so only include content changes that cater to that audience. For example, if a new feature is advanced, marked as experimental, or otherwise doesn't qualify as a "beginner" level feature, don't include it in the course content since we don't want to overwhelm learners. Determine what is most relevant and helpful for beginners learning about the Copilot CLI.
 
-Read all of the readme files in the repo and compare the features documented there against what you found in Step 1. Also check existing pull requests to see if any updates are already in progress. DO NOT duplicate efforts if an update has already been proposed in an open PR.
+Read all of the readme files in the repo and compare the features documented there against what you found in Step 1.
 Identify:
 
 - **Missing features** — new capabilities not yet documented
@@ -49,13 +53,13 @@ Identify:
 
 If there is nothing new or everything is already up to date, stop here and report that no updates are needed. 
 
-## Step 3 — Update the course content
+## Step 4 — Update the course content
 
 If updates are needed, make a decision on which chapter(s) need to be updated.
 
 If the new information can be added to existing chapter(s), edit those chapters to include refinements, new sections, or updated information as needed. Remember that this course targets beginners, so ensure that any new content is explained clearly and simply, with examples if possible.
 
-## Step 4 — Open a pull request
+## Step 5 — Open a pull request
 
 Create a pull request with your changes, using the `main` branch as the base branch. The PR title should summarize what was updated (e.g., "Add /plan command documentation"). The PR body should list:
 


### PR DESCRIPTION
## Changes

- **Schedule**: Changed from `daily` to `weekly on monday` (compiles to `38 11 * * 1` — 11:38 AM UTC / 4:38 AM PT)
- **Duplicate prevention**: Added Step 2 instructing the agent to read existing open bot PRs, identify which features they already cover, and exclude those from its work — preventing duplicate PRs for the same feature
- **Renumbered** steps 3–5 accordingly
- **Recompiled** lock file