### PR TITLE
fix(book): support case-insensitive partial author matching

### DIFF
--- a/samples/book-app-project/books.py
+++ b/samples/book-app-project/books.py
@@ -68,5 +68,6 @@ class BookCollection:
         return False
 
     def find_by_author(self, author: str) -> List[Book]:
-        """Find all books by a given author."""
-        return [b for b in self.books if b.author.lower() == author.lower()]
+        """Find all books by a given author (case-insensitive, partial match)."""
+        key = author.lower().strip()
+        return [b for b in self.books if key in b.author.lower()]

--- a/samples/book-app-project/tests/test_find_by_author.py
+++ b/samples/book-app-project/tests/test_find_by_author.py
@@ -1,0 +1,56 @@
+import sys
+import os
+import pytest
+
+# ensure package can be imported
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import books
+from books import BookCollection
+
+
+@pytest.fixture(autouse=True)
+def use_temp_data_file(tmp_path, monkeypatch):
+    """Use a temporary data file for each test."""
+    temp_file = tmp_path / "data.json"
+    temp_file.write_text("[]")
+    monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
+
+
+def test_find_by_author_partial_match_returns_multiple():
+    # arrange
+    collection = BookCollection()
+    collection.add_book("Pride and Prejudice", "Jane Austen", 1813)
+    collection.add_book("Sense and Sensibility", "Austen, Jane", 1811)
+    collection.add_book("Dune", "Frank Herbert", 1965)
+
+    # act
+    results = collection.find_by_author("Austen")
+
+    # assert
+    assert len(results) == 2
+
+
+def test_find_by_author_case_variation_matches():
+    # arrange
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+
+    # act
+    results = collection.find_by_author("gEoRgE orWeLL")
+
+    # assert
+    assert len(results) == 1
+    assert results[0].title == "1984"
+
+
+def test_find_by_author_no_matches_returns_empty_list():
+    # arrange
+    collection = BookCollection()
+    collection.add_book("The Hobbit", "J.R.R. Tolkien", 1937)
+
+    # act
+    results = collection.find_by_author("Nonexistent Author")
+
+    # assert
+    assert results == []


### PR DESCRIPTION
Change BookCollection.find_by_author to perform case-insensitive substring matches (using .lower().strip()) instead of requiring exact equality. This makes author searches more forgiving (partial and case-variant matches).\n\nAdd tests: samples/book-app-project/tests/test_find_by_author.py covering partial matches, case variations, and no-match behavior.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>