### PR TITLE
[bot] Update chapters 01–02 with Copilot CLI v1.0.35/v1.0.36 features

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -377,6 +377,8 @@ These commands are great to learn initially as you're getting started with Copil
 
 > 💡 **`/ask` vs regular chat**: Normally every message you send becomes part of the ongoing conversation and affects future responses. `/ask` is an "off the record" shortcut — perfect for quick one-off questions like `/ask What does YAML mean?` without polluting your session context.
 
+> 💡 **Tab-completion**: When typing a slash command, press **Tab** to auto-complete the command name or cycle through available subcommands and arguments. This is especially handy when you can't remember the exact name of a command.
+
 That's it for getting started! As you become comfortable, you can explore additional commands.
 
 > 📚 **Official Documentation**: [CLI command reference](https://docs.github.com/copilot/reference/cli-command-reference) for the complete list of commands and flags.
@@ -436,12 +438,13 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/clear` | Abandons the current session (no history saved) and starts a fresh conversation |
 | `/compact` | Summarize conversation to reduce context usage |
 | `/context` | Show context window token usage and visualization |
+| `/keep-alive` | Prevent your system from sleeping while Copilot CLI is active — handy for long-running tasks on a laptop |
 | `/new` | Ends the current session (saving it to history for search/resume) and starts a fresh conversation. |
-| `/resume` | Switch to a different session (optionally specify session ID) |
+| `/resume` | Switch to a different session (optionally specify session ID or name) |
 | `/rename` | Rename the current session (omit the name to auto-generate one) |
 | `/rewind` | Open a timeline picker to roll back to any earlier point in the conversation |
 | `/usage` | Display session usage metrics and statistics |
-| `/session` | Show session info and workspace summary |
+| `/session` | Show session info and workspace summary; use `/session delete`, `/session delete <id>`, or `/session delete-all` to remove sessions |
 | `/share` | Export session as a markdown file, GitHub gist, or self-contained HTML file |
 
 ### Display
@@ -645,6 +648,7 @@ The examples used `/plan` for a search feature and `-p` for batch reviews. Now t
 | Typing `exit` instead of `/exit` | Copilot CLI treats "exit" as a prompt, not a command | Slash commands always start with `/` |
 | Using `-p` for multi-turn conversations | Each `-p` call is isolated with no memory of previous calls | Use interactive mode (`copilot`) for conversations that build on context |
 | Forgetting quotes around prompts with `$` or `!` | Shell interprets special characters before Copilot CLI sees them | Wrap prompts in quotes: `copilot -p "What does $HOME mean?"` |
+| Pressing Esc once to cancel a running task | A single Esc no longer cancels in-flight work (to prevent accidents) | Press **Esc twice** to cancel while Copilot CLI is processing |
 
 ### Troubleshooting
 

--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -304,10 +304,10 @@ copilot --continue
 copilot --resume
 
 # Or resume a specific session by ID
-copilot --resume abc123
+copilot --resume=abc123
 
 # Or resume by the name you gave the session
-copilot --resume=book-app-review
+copilot --resume="my book app review"
 ```
 
 > 💡 **How do I find a session ID?** You don't need to memorize them. Running `copilot --resume` without an ID shows an interactive list of your previous sessions, their names, IDs, and when they were last active. Just pick the one you want.

--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -305,11 +305,14 @@ copilot --resume
 
 # Or resume a specific session by ID
 copilot --resume abc123
+
+# Or resume by the name you gave the session
+copilot --resume=book-app-review
 ```
 
 > 💡 **How do I find a session ID?** You don't need to memorize them. Running `copilot --resume` without an ID shows an interactive list of your previous sessions, their names, IDs, and when they were last active. Just pick the one you want.
 >
-> **What about multiple terminals?** Each terminal window is its own session with its own context. If you have Copilot CLI open in three terminals, that's three separate sessions. Running `--resume` from any terminal lets you browse all of them. The `--continue` flag grabs whichever session was closed most recently, no matter which terminal it was in.
+> **What about multiple terminals?** Each terminal window is its own session with its own context. If you have Copilot CLI open in three terminals, that's three separate sessions. Running `--resume` from any terminal lets you browse all of them. The `--continue` flag grabs the session from the current working directory first; if none exists there, it picks the most recently active session.
 >
 > **Can I switch sessions without restarting?** Yes. Use the `/resume` slash command from inside an active session:
 > ```
@@ -319,13 +322,33 @@ copilot --resume abc123
 
 ### Organize Your Sessions
 
-Give sessions meaningful names so you can find them later:
+Give sessions meaningful names so you can find them later. You can name a session when you start it, or rename it at any time while inside the session:
 
 ```bash
+# Name a session right when you start it
+copilot --name book-app-review
+
+# Or rename the current session from inside
 copilot
 
 > /rename book-app-review
 # Session renamed for easier identification
+```
+
+Once a session is named, you can resume it directly by name without browsing through a list:
+
+```bash
+copilot --resume=book-app-review
+```
+
+To clean up sessions you no longer need, use `/session delete` from inside a session:
+
+```bash
+copilot
+
+> /session delete            # Deletes the current session
+> /session delete abc123     # Deletes a specific session by ID
+> /session delete-all        # Deletes all sessions (use with care!)
 ```
 
 ### Check and Manage Context
@@ -363,10 +386,9 @@ Context usage: 62k/200k tokens (31%)
 Imagine this workflow across multiple days:
 
 ```bash
-# Monday: Start book app review
-copilot
+# Monday: Start book app review with a name right from the beginning
+copilot --name book-app-review
 
-> /rename book-app-review
 > @samples/book-app-project/books.py
 > Review and number all code quality issues
 
@@ -384,8 +406,8 @@ Quality Issues Found:
 ```
 
 ```bash
-# Wednesday: Resume exactly where you left off
-copilot --continue
+# Wednesday: Resume exactly where you left off, by name
+copilot --resume=book-app-review
 
 > What issues remain unfixed from our book app review?
 
@@ -410,7 +432,7 @@ No re-explaining. No re-reading files. Just continue working.
 
 ---
 
-**🎉 You now know the essentials!** The `@` syntax, session management (`--continue`/`--resume`/`/rename`), and context commands (`/context`/`/clear`) are enough to be highly productive. Everything below is optional. Return to it when you're ready.
+**🎉 You now know the essentials!** The `@` syntax, session management (`--name`/`--continue`/`--resume`/`/rename`), and context commands (`/context`/`/clear`) are enough to be highly productive. Everything below is optional. Return to it when you're ready.
 
 ---
 
@@ -858,7 +880,7 @@ copilot --add-dir /path/to/directory
 
 1. **`@` syntax** gives Copilot CLI context about files, directories, and images
 2. **Multi-turn conversations** build on each other as context accumulates
-3. **Sessions auto-save**: use `--continue` or `--resume` to pick up where you left off
+3. **Sessions auto-save**: name them at startup with `--name`, resume by name with `--resume=<name>`, or use `--continue` to pick up the most recent session
 4. **Context windows** have limits: manage them with `/clear`, `/compact`, `/context`, `/new`, and `/rewind`
 5. **Permission flags** (`--add-dir`, `--allow-all`) control multi-directory access. Use them wisely!
 6. **Image references** (`@screenshot.png`) help debug UI issues visually


### PR DESCRIPTION
## What's new in Copilot CLI v1.0.35 and v1.0.36

Two stable releases shipped on **April 23–24, 2026** with several beginner-friendly improvements that were not yet reflected in the course content.

### New features found

**v1.0.35 (April 23, 2026)** — [Release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.35)
- Slash commands now support **tab-completion** for arguments and subcommands
- **`--name`** flag: name a session at startup (`copilot --name my-session`)
- **`--resume=<name>`**: resume a session by name instead of ID
- **`--continue`** now prefers the session from the current working directory
- **`/session delete`**, `/session delete <id>`, and `/session delete-all` subcommands for cleaning up sessions

**v1.0.36 (April 24, 2026)** — [Release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.36)
- **`/keep-alive`** is now available without experimental mode — prevents system sleep during long-running tasks
- **Double Esc** is now required to cancel in-flight work (previously single Esc), preventing accidental interruptions

---

## Course sections updated

### Chapter 01: Setup and First Steps (`01-setup-and-first-steps/README.md`)
- Added tab-completion tip after the Essential Slash Commands section
- Added `/keep-alive` to the Session commands reference table
- Updated `/session` table entry to document `delete`, `delete <id>`, and `delete-all` subcommands
- Updated `/resume` table entry to note you can specify a name (not just an ID)
- Added double-Esc behavior change to the Common Mistakes table

### Chapter 02: Context and Conversations (`02-context-conversations/README.md`)
- Added `--resume=<name>` example to the "Resume a Specific Session" section
- Updated `--continue` note to reflect it prefers the current working directory's session
- Expanded "Organize Your Sessions" to show `--name` at startup, `--resume=<name>` for quick resume, and `/session delete` commands
- Updated the multi-day workflow example (Monday/Wednesday) to use `--name` and `--resume=<name>`
- Updated the essentials callout and Key Takeaways summary to mention `--name`

---

## Source announcements
- https://github.com/github/copilot-cli/releases/tag/v1.0.35
- https://github.com/github/copilot-cli/releases/tag/v1.0.36




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/24994153969/agentic_workflow) · ● 1.3M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 24994153969, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/24994153969 -->

<!-- gh-aw-workflow-id: course-updater -->