### PR TITLE
docs: Remove the mention of AGENTS.md generation by the /init command

### DIFF
--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -430,7 +430,7 @@ Copilot will scan your project and create tailored instruction files. You can ed
 
 `AGENTS.md` is the recommended format. It's an [open standard](https://agents.md/) that works across Copilot and other AI coding tools. Place it in your repository root and Copilot reads it automatically. This project's own [AGENTS.md](../AGENTS.md) is a working example.
 
-A typical `AGENTS.md` describes your project context, code style, security requirements, and testing standards. Use `/init` to generate one, or write your own following the pattern in our example file.
+A typical `AGENTS.md` describes your project context, code style, security requirements, and testing standards. Write your own following the pattern in our example file.
 
 ### Custom Instruction Files (.instructions.md)
 


### PR DESCRIPTION
Thank you for maintaining this excellent project. I am submitting this PR to propose a minor correction to the `README.md`.

**Description of the Issue:**
In the section regarding `AGENTS.md`, there is a statement mentioning that the `/init` command generates this file. However, to the best of my knowledge, the `/init` command generates an `.github/copilot-instructions.md` file, but it does not generate `AGENTS.md`. 

**Verification:**
To confirm, I tested this locally using both the `/init` command alone and with specific prompts. In both cases, `AGENTS.md` was not generated. 
*(Environment: `@github/copilot@1.0.36`)*

**Changes Made:**
To prevent any potential confusion for users, I have **removed** the sentence that claims the `/init` command creates `AGENTS.md`.

Please let me know if my understanding is incorrect or if I have missed any specific context. I apologize in advance if that is the case.

Thank you for your time and review!