### PR TITLE
[bot] docs: add shell completion, /chronicle command, and permission persistence updates

### DIFF
--- a/00-quick-start/README.md
+++ b/00-quick-start/README.md
@@ -87,20 +87,30 @@ Follow these steps if you'd like to run Copilot CLI on your local machine with t
     curl -fsSL https://gh.io/copilot-install | bash
     ```
 
-> 💡 **Tip: Enable shell tab completion** — Once installed, you can set up tab completion so pressing **Tab** in your terminal auto-completes `copilot` commands and flags. Run the command for your shell:
->
-> ```bash
-> # Bash
-> copilot completion bash >> ~/.bashrc && source ~/.bashrc
->
-> # Zsh
-> copilot completion zsh >> ~/.zshrc && source ~/.zshrc
->
-> # Fish
-> copilot completion fish > ~/.config/fish/completions/copilot.fish
-> ```
->
-> After running this once, you can type `copilot ` and press **Tab** to see available subcommands, or start typing a flag like `--` and press **Tab** to auto-complete it. Entirely optional, but handy for beginners exploring the CLI.
+<details>
+<summary>Optional: Enable shell tab completion</summary>
+
+Shell tab completion lets you press **Tab** to complete `copilot` subcommands, command options, and some option values. This is optional, but it can be handy once you're comfortable using the CLI.
+
+Copilot CLI currently supports completion scripts for Bash, Zsh, and Fish:
+
+```shell
+# Bash, current session only
+source <(copilot completion bash)
+
+# Bash, persistent on Linux
+copilot completion bash | sudo tee /etc/bash_completion.d/copilot
+
+# Zsh
+copilot completion zsh > "${fpath[1]}/_copilot"
+
+# Fish
+copilot completion fish > ~/.config/fish/completions/copilot.fish
+```
+
+Restart your shell after adding persistent completion. PowerShell is supported for running Copilot CLI on Windows, but `copilot completion` currently supports only Bash, Zsh, and Fish.
+
+</details>
 
 ---
 
@@ -112,7 +122,7 @@ Open a terminal window at the root of the `copilot-cli-for-beginners` repository
 copilot
 ```
 
-You'll be asked to trust the folder containing the repository (if you haven't already). Once you approve it, that approval is automatically saved — you won't need to re-approve the same folder in future sessions.
+You'll be asked to trust the folder containing the repository (if you haven't already). You can trust it one time or across all future sessions.
 
 <img src="images/copilot-trust.png" alt="Trusting files in a folder with the Copilot CLI" width="800"/>
 

--- a/00-quick-start/README.md
+++ b/00-quick-start/README.md
@@ -87,6 +87,21 @@ Follow these steps if you'd like to run Copilot CLI on your local machine with t
     curl -fsSL https://gh.io/copilot-install | bash
     ```
 
+> 💡 **Tip: Enable shell tab completion** — Once installed, you can set up tab completion so pressing **Tab** in your terminal auto-completes `copilot` commands and flags. Run the command for your shell:
+>
+> ```bash
+> # Bash
+> copilot completion bash >> ~/.bashrc && source ~/.bashrc
+>
+> # Zsh
+> copilot completion zsh >> ~/.zshrc && source ~/.zshrc
+>
+> # Fish
+> copilot completion fish > ~/.config/fish/completions/copilot.fish
+> ```
+>
+> After running this once, you can type `copilot ` and press **Tab** to see available subcommands, or start typing a flag like `--` and press **Tab** to auto-complete it. Entirely optional, but handy for beginners exploring the CLI.
+
 ---
 
 ## Authentication
@@ -97,7 +112,7 @@ Open a terminal window at the root of the `copilot-cli-for-beginners` repository
 copilot
 ```
 
-You'll be asked to trust the folder containing the repository (if you haven't already). You can trust it one time or across all future sessions.
+You'll be asked to trust the folder containing the repository (if you haven't already). Once you approve it, that approval is automatically saved — you won't need to re-approve the same folder in future sessions.
 
 <img src="images/copilot-trust.png" alt="Trusting files in a folder with the Copilot CLI" width="800"/>
 

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -435,7 +435,6 @@ That's it for getting started! As you become comfortable, you can explore additi
 
 | Command | What It Does |
 |---------|--------------|
-| `/chronicle` | Browse your session history — view past sessions, which files you worked on, and what changed |
 | `/clear` | Abandons the current session (no history saved) and starts a fresh conversation |
 | `/compact` | Summarize conversation to reduce context usage |
 | `/context` | Show context window token usage and visualization |

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -435,6 +435,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 
 | Command | What It Does |
 |---------|--------------|
+| `/chronicle` | Browse your session history — view past sessions, which files you worked on, and what changed |
 | `/clear` | Abandons the current session (no history saved) and starts a fresh conversation |
 | `/compact` | Summarize conversation to reduce context usage |
 | `/context` | Show context window token usage and visualization |


### PR DESCRIPTION
## What's New in Copilot CLI (v1.0.37 - v1.0.40)

This PR updates the course content to reflect recent Copilot CLI releases from the past 7 days (April 27 - May 4, 2026). Only beginner-friendly, stable content is included.

---

### Sections Updated

**Chapter 00 - Quick Start (`00-quick-start/README.md`)**

1. **Optional shell tab completion**: Added an expandable optional section after installation. It links the beginner-friendly explanation to the officially documented `copilot completion` support for Bash, Zsh, and Fish, and notes that PowerShell is not currently supported by `copilot completion`.

2. **Permission wording**: Kept the trust-folder wording aligned with the course flow and avoided over-specifying behavior that may vary by CLI version or trust choice.

**Chapter 01 - First Steps (`01-setup-and-first-steps/README.md`)**

No command table changes are included. `/chronicle` was intentionally omitted because the command reference still marks it as experimental.

---

### Source Announcements

- [v1.0.37 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.37)
- [v1.0.39 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.39)
- [v1.0.40 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.40)
- [Copilot CLI command reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference#using-copilot-completion)