### PR TITLE
[bot] docs(ch05): document multi-skill invocation and mid-input slash commands (v1.0.44)

### DIFF
--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -101,6 +101,20 @@ While auto-triggering is the primary way skills work, you can also **invoke skil
 
 This gives you explicit control when you want to ensure a specific skill is used.
 
+#### Combining Multiple Skills in One Message
+
+You can invoke **more than one skill in a single message**, and the skill slash command can appear anywhere in your prompt — not just at the beginning. This is handy when you want two different checks done in one go:
+
+```bash
+> Check @samples/book-app-project/book_app.py with /code-checklist and also run /generate-tests for it
+
+> Review the auth module /security-audit then /code-checklist the result
+```
+
+Copilot will apply each named skill in the same response, saving you from sending multiple separate messages.
+
+> 💡 **Tip**: Put the skill slash commands wherever they feel most natural in your sentence. You can put them at the start, middle, or end of your message.
+
 > 📝 **Skills vs Agents Invocation**: Don't confuse skill invocation with agent invocation:
 > - **Skills**: `/skill-name <prompt>`, e.g., `/code-checklist Check this file`
 > - **Agents**: `/agent` (select from list) or `copilot --agent <name>` (command line)


### PR DESCRIPTION
## What changed in Copilot CLI

**Copilot CLI v1.0.44** (released 2026-05-08) introduced two related improvements to how slash commands and skills work:

- **Slash commands can now appear anywhere in a message** — not just at the very start of your input
- **Multiple skills can be invoked in a single message** — you can combine `/code-checklist` and `/generate-tests` in one prompt instead of sending two separate messages

## What was updated

**Chapter 05 – Skills System (`05-skills/README.md`)**

Added a new `#### Combining Multiple Skills in One Message` subsection inside the existing *Direct Slash Command Invocation* section. It:

- Explains that skill slash commands can be placed at the start, middle, or end of a message
- Shows a concrete example using the course's `book_app.py` sample file with both `/code-checklist` and `/generate-tests`
- Includes a tip callout reinforcing the flexibility of placement

No other chapters required changes — the existing slash command tables in Chapter 01 describe general command behavior that is still accurate.

## Source

- [GitHub Copilot CLI v1.0.44 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.44)




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/25670268507/agentic_workflow) · ● 700.2K · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 25670268507, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/25670268507 -->

<!-- gh-aw-workflow-id: course-updater -->