### PR TITLE
[bot] docs(ch04): document applyTo frontmatter for instruction files

### DIFF
--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -446,6 +446,32 @@ For teams that want more granular control, split instructions into topic-specifi
 
 > 💡 **Note**: Instruction files work with any language. This example uses Python to match our course project, but you can create similar files for TypeScript, Go, Rust, or any technology your team uses.
 
+#### Scoping Instructions with `applyTo`
+
+By default, an instruction file applies to every conversation. To limit it to specific file types, add an `applyTo` field in YAML frontmatter (the block between `---` markers at the very top of the file):
+
+```markdown
+---
+applyTo: "**/*.py"
+---
+# Python Standards
+Always follow PEP 8 style conventions.
+Use type hints in all function signatures.
+```
+
+With `applyTo: "**/*.py"`, Copilot only loads that instruction file when you are working with Python files. Instructions for Python style never clutter a conversation about, say, a Dockerfile or a SQL query.
+
+Here are some common patterns:
+
+| `applyTo` value | When it applies |
+|---|---|
+| `"**/*.py"` | Any Python file |
+| `"**/*.{ts,tsx}"` | TypeScript and TSX files |
+| `"tests/**"` | Any file inside a `tests/` folder |
+| (no frontmatter) | Every conversation — the default |
+
+> 💡 **Tip**: Wrap the glob pattern in quotes (e.g., `"**/*.py"`) to ensure it is interpreted correctly across all operating systems and shells.
+
 **Finding community instruction files**: Browse [github/awesome-copilot](https://github.com/github/awesome-copilot) for pre-made instruction files covering .NET, Angular, Azure, Python, Docker, and many more technologies.
 
 ### Disabling Custom Instructions


### PR DESCRIPTION
## What changed

Added a new **"Scoping Instructions with `applyTo`"** subsection to the Custom Instruction Files section in **Chapter 04 (Agents & Custom Instructions)**.

### New content includes:
- Explanation of the `applyTo` YAML frontmatter field and what it does
- A worked example scoping a Python-standards instruction file to `**/*.py`
- A table of common `applyTo` glob patterns (`**/*.py`, `**/*.{ts,tsx}`, `tests/**`, and the default "no frontmatter" case)
- A tip recommending quoted glob patterns for cross-platform reliability

## Why this update

Copilot CLI **v1.0.48 (2026-05-14)** fixed a bug where unquoted glob patterns in the `applyTo` frontmatter were silently ignored. The fix makes the feature reliably available for all users.

The course already documented `.instructions.md` files, but never explained the `applyTo` field — meaning learners had no way to know they could scope instructions to specific file types. This is a beginner-friendly feature: it prevents irrelevant instructions from cluttering conversations and encourages more focused instruction files.

## Sections updated

- `04-agents-custom-instructions/README.md` — "Custom Instruction Files (.instructions.md)" section, new `#### Scoping Instructions with applyTo` subsection added

## Source

- [Copilot CLI v1.0.48 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.48): *"Instruction files with unquoted glob patterns in applyTo frontmatter (e.g. `applyTo: **/*.ts`) are now applied correctly"*




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/26034456603/agentic_workflow) · ● 526.2K · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 26034456603, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/26034456603 -->

<!-- gh-aw-workflow-id: course-updater -->