### PR TITLE
Remove GitHub Copilot Dev Days image and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ This course is designed for:
 - **Terminal users** who prefer keyboard-driven workflows over IDE integrations
 - **Teams looking to standardize** AI-assisted code review and development practices
 
-<a href="https://aka.ms/githubcopilotdevdays" target="_blank">
-  <picture>
-    <img src="./images/copilot-dev-days.png" alt="GitHub Copilot Dev Days - Find or host an event" width="100%" />
-  </picture>
-</a>
-
 ## 🎯 What You'll Learn
 
 This hands-on course takes you from zero to productive with GitHub Copilot CLI. You'll work with a single Python book collection app throughout all chapters, progressively improving it using AI-assisted workflows. By the end, you'll confidently use AI to review code, generate tests, debug issues, and automate workflows: all from your terminal.


### PR DESCRIPTION
Removed promotional image and link for GitHub Copilot Dev Days from the README.