### PR TITLE
feat(book-app): add list unread books command

### DIFF
--- a/samples/book-app-project/book_app.py
+++ b/samples/book-app-project/book_app.py
@@ -59,12 +59,24 @@ def handle_find():
     show_books(books)
 
 
+def handle_list_unread() -> None:
+    books = collection.get_unread_books()
+    if not books:
+        print("\nNo unread books found.\n")
+        return
+    print("\nUnread Books:\n")
+    for index, book in enumerate(books, start=1):
+        print(f"{index}. {book.title} by {book.author} ({book.year})")
+    print()
+
+
 def show_help():
     print("""
 Book Collection Helper
 
 Commands:
   list     - Show all books
+  unread   - Show only unread books
   add      - Add a new book
   remove   - Remove a book by title
   find     - Find books by author
@@ -81,6 +93,8 @@ def main():
 
     if command == "list":
         handle_list()
+    elif command == "unread":
+        handle_list_unread()
     elif command == "add":
         handle_add()
     elif command == "remove":

--- a/samples/book-app-project/books.py
+++ b/samples/book-app-project/books.py
@@ -67,6 +67,10 @@ class BookCollection:
             return True
         return False
 
+    def get_unread_books(self) -> List[Book]:
+        """Return all books that have not been marked as read."""
+        return [b for b in self.books if not b.read]
+
     def find_by_author(self, author: str) -> List[Book]:
         """Find all books by a given author."""
         return [b for b in self.books if b.author.lower() == author.lower()]

--- a/samples/book-app-project/tests/test_books.py
+++ b/samples/book-app-project/tests/test_books.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
 import books
+import book_app
 from books import BookCollection
 
 
@@ -51,3 +52,141 @@ def test_remove_book_invalid():
     collection = BookCollection()
     result = collection.remove_book("Nonexistent Book")
     assert result is False
+
+
+def test_get_unread_books_returns_only_unread():
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    collection.add_book("Dune", "Frank Herbert", 1965)
+    collection.mark_as_read("1984")
+
+    unread = collection.get_unread_books()
+
+    assert len(unread) == 1
+    assert unread[0].title == "Dune"
+
+
+def test_get_unread_books_empty_collection():
+    collection = BookCollection()
+
+    unread = collection.get_unread_books()
+
+    assert unread == []
+
+
+def test_get_unread_books_all_read():
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    collection.mark_as_read("1984")
+
+    unread = collection.get_unread_books()
+
+    assert unread == []
+
+
+def test_get_unread_books_none_read():
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    collection.add_book("Dune", "Frank Herbert", 1965)
+
+    unread = collection.get_unread_books()
+
+    assert len(unread) == 2
+
+
+def test_get_unread_books_does_not_modify_collection():
+    collection = BookCollection()
+    collection.add_book("Dune", "Frank Herbert", 1965)
+
+    collection.get_unread_books()
+
+    assert len(collection.books) == 1
+
+
+# ---------------------------------------------------------------------------
+# handle_list_unread output tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def patched_collection(tmp_path, monkeypatch):
+    """Patch book_app's global collection with a fresh isolated instance."""
+    temp_file = tmp_path / "data.json"
+    temp_file.write_text("[]")
+    monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
+    fresh = BookCollection()
+    monkeypatch.setattr(book_app, "collection", fresh)
+    return fresh
+
+
+def test_handle_list_unread_prints_unread_books(patched_collection, capsys):
+    patched_collection.add_book("Dune", "Frank Herbert", 1965)
+    patched_collection.add_book("1984", "George Orwell", 1949)
+    patched_collection.mark_as_read("1984")
+
+    book_app.handle_list_unread()
+
+    output = capsys.readouterr().out
+    assert "Dune" in output
+    assert "1984" not in output
+
+
+def test_handle_list_unread_shows_no_unread_message_when_all_read(patched_collection, capsys):
+    patched_collection.add_book("1984", "George Orwell", 1949)
+    patched_collection.mark_as_read("1984")
+
+    book_app.handle_list_unread()
+
+    output = capsys.readouterr().out
+    assert "No unread books found" in output
+
+
+def test_handle_list_unread_shows_no_unread_message_when_empty(patched_collection, capsys):
+    book_app.handle_list_unread()
+
+    output = capsys.readouterr().out
+    assert "No unread books found" in output
+
+
+def test_handle_list_unread_includes_author_and_year(patched_collection, capsys):
+    patched_collection.add_book("Dune", "Frank Herbert", 1965)
+
+    book_app.handle_list_unread()
+
+    output = capsys.readouterr().out
+    assert "Frank Herbert" in output
+    assert "1965" in output
+
+
+# ---------------------------------------------------------------------------
+# main() command routing tests
+# ---------------------------------------------------------------------------
+
+def test_main_routes_unread_command(patched_collection, monkeypatch, capsys):
+    patched_collection.add_book("Dune", "Frank Herbert", 1965)
+    monkeypatch.setattr(sys, "argv", ["book_app.py", "unread"])
+
+    book_app.main()
+
+    output = capsys.readouterr().out
+    assert "Dune" in output
+
+
+def test_main_unread_command_case_insensitive(patched_collection, monkeypatch, capsys):
+    patched_collection.add_book("Dune", "Frank Herbert", 1965)
+    monkeypatch.setattr(sys, "argv", ["book_app.py", "UNREAD"])
+
+    book_app.main()
+
+    output = capsys.readouterr().out
+    assert "Dune" in output
+
+
+# ---------------------------------------------------------------------------
+# show_help includes unread command
+# ---------------------------------------------------------------------------
+
+def test_show_help_includes_unread_command(capsys):
+    book_app.show_help()
+
+    output = capsys.readouterr().out
+    assert "unread" in output


### PR DESCRIPTION
## Summary

Adds a `list unread` command to the Python book app so users can quickly see books they haven't read yet.

## Changes

### `samples/book-app-project/books.py`
- Added `get_unread_books() -> List[Book]` method to `BookCollection` — returns a filtered list of books where `read is False`

### `samples/book-app-project/book_app.py`
- Added `handle_list_unread() -> None` handler that prints unread books with author and year
- Wired `unread` command in `main()` (case-insensitive, consistent with other commands)
- Updated `show_help()` to document the new `unread` command

### `samples/book-app-project/tests/test_books.py`
- Added 12 new tests across three groups:
  - **Unit** (`get_unread_books`): happy path, empty collection, all read, none read, non-mutation
  - **Output** (`handle_list_unread`): correct books printed, empty/all-read message, author+year included
  - **Routing** (`main`): dispatches `unread` command, case-insensitive; help text includes `unread`

## Usage

```bash
python book_app.py unread
```

## Test Results

```
17 passed in 0.22s
```
