### PR TITLE
Update README.md

### DIFF
--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -370,9 +370,7 @@ copilot
 
 For example, if you tell Copilot CLI "I always prefer pytest for Python testing", it can remember that preference and apply it automatically in future sessions. All without you having to repeat it.
 
-> 💡 **Memory vs. Sessions**: Sessions save the *conversation history* so you can resume a specific task. Memory saves *preferences and context* that apply across all your work. Think of sessions as project notebooks and memory as your personal notepad.
-
-> 🔒 **Privacy note**: Memory is scoped either to your user account (visible to you across all repos) or to a specific repository (shared with collaborators). The CLI tells you which scope applies whenever it stores something.
+> 💡 **Memory vs. Sessions**: Sessions save conversation history so you can resume a specific task. Memory saves reusable repository facts and user preferences that Copilot can apply in future work. Think of sessions as task notebooks, and memory as reusable context Copilot can carry forward.
 
 ### Check and Manage Context
 


### PR DESCRIPTION
This pull request updates the documentation in the `02-context-conversations/README.md` file to clarify the distinction between "memory" and "sessions" in Copilot CLI. The most important change is an improved explanation of how memory and sessions work, making it easier for users to understand their purposes.

Documentation improvements:

* Clarified the difference between "memory" and "sessions" in Copilot CLI, emphasizing that sessions store task-specific conversation history, while memory stores reusable repository facts and user preferences for future use.