### PR TITLE
[bot] Add /voice command and -r resume shorthand from recent CLI releases

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -454,6 +454,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 |---------|--------------|
 | `/statusline` (or `/footer`) | Customize which items appear in the status bar at the bottom of the session (directory, branch, effort, context window, quota) |
 | `/theme` | View or set terminal theme |
+| `/voice` | Dictate your prompt using local speech-to-text — speak naturally instead of typing |
 
 ### Help and Feedback
 

--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -303,6 +303,9 @@ copilot --continue
 # Pick from a list of sessions interactively
 copilot --resume
 
+# -r is a shorthand for --resume (saves some typing!)
+copilot -r
+
 # Or resume a specific session by ID
 copilot --resume=abc123
 


### PR DESCRIPTION
## What's new in recent Copilot CLI releases

Two beginner-relevant features were shipped in the past 7 days:

| Release | Feature |
|---------|---------|
| [v1.0.59](https://github.com/github/copilot-cli/releases/tag/v1.0.59) (2026-06-02) | `/voice` command — dictate prompts using local speech-to-text models |
| [v1.0.60](https://github.com/github/copilot-cli/releases/tag/v1.0.60) (2026-06-05) | `-r` flag as shorthand for `--resume` |

Other recent changes (Rubber Duck auto-invocation, experimental scheduled prompts, `/experimental` UI) were either too advanced for beginners, experimental/opt-in, or had their defaults toggled back within the same release window and were left out of this update.

## Sections updated

### Chapter 01: First Steps (`01-setup-and-first-steps/README.md`)
- Added `/voice` to the **Display** table in the *Additional Commands* reference section. Described as: *Dictate your prompt using local speech-to-text — speak naturally instead of typing.*

### Chapter 02: Context and Conversations (`02-context-conversations/README.md`)
- Added `-r` as a shorthand for `--resume` in the *Resume a Specific Session* code block, with a brief comment explaining it saves typing.

## Source announcements

- v1.0.59 release notes: https://github.com/github/copilot-cli/releases/tag/v1.0.59
- v1.0.60 release notes: https://github.com/github/copilot-cli/releases/tag/v1.0.60




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/27139245625/agentic_workflow) · ● 732.1K · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 27139245625, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/27139245625 -->

<!-- gh-aw-workflow-id: course-updater -->