### PR TITLE
feat(book-app-cs): add list-unread and mark-read commands

### DIFF
--- a/samples/book-app-project-cs/Program.cs
+++ b/samples/book-app-project-cs/Program.cs
@@ -3,11 +3,11 @@ using BookApp.Services;
 
 var collection = new BookCollection();
 
-void ShowBooks(List<Book> books)
+void ShowBooks(List<Book> books, string emptyMessage = "No books found.")
 {
     if (books.Count == 0)
     {
-        Console.WriteLine("No books found.");
+        Console.WriteLine(emptyMessage);
         return;
     }
 
@@ -27,6 +27,12 @@ void HandleList()
 {
     var books = collection.ListBooks();
     ShowBooks(books);
+}
+
+void HandleListUnread()
+{
+    var books = collection.GetUnreadBooks();
+    ShowBooks(books, "No unread books found.");
 }
 
 void HandleAdd()
@@ -64,6 +70,23 @@ void HandleRemove()
     Console.WriteLine("\nBook removed if it existed.\n");
 }
 
+void HandleMarkRead()
+{
+    Console.WriteLine("\nMark a Book as Read\n");
+
+    Console.Write("Enter the title of the book to mark as read: ");
+    var title = Console.ReadLine()?.Trim() ?? "";
+
+    if (collection.MarkAsRead(title))
+    {
+        Console.WriteLine("\nBook marked as read.\n");
+    }
+    else
+    {
+        Console.WriteLine($"\nNo book found with title '{title}'.\n");
+    }
+}
+
 void HandleFind()
 {
     Console.WriteLine("\nFind Books by Author\n");
@@ -82,11 +105,13 @@ void ShowHelp()
     Book Collection Helper
 
     Commands:
-      list     - Show all books
-      add      - Add a new book
-      remove   - Remove a book by title
-      find     - Find books by author
-      help     - Show this help message
+      list        - Show all books
+      list-unread - Show only unread books
+      add         - Add a new book
+      remove      - Remove a book by title
+      mark-read   - Mark a book as read by title
+      find        - Find books by author
+      help        - Show this help message
     """);
 }
 
@@ -103,11 +128,17 @@ switch (command)
     case "list":
         HandleList();
         break;
+    case "list-unread":
+        HandleListUnread();
+        break;
     case "add":
         HandleAdd();
         break;
     case "remove":
         HandleRemove();
+        break;
+    case "mark-read":
+        HandleMarkRead();
         break;
     case "find":
         HandleFind();

--- a/samples/book-app-project-cs/README.md
+++ b/samples/book-app-project-cs/README.md
@@ -29,9 +29,11 @@ It can add, remove, and list books. Also mark them as read.
 
 ```bash
 dotnet run -- list
+dotnet run -- list-unread
 dotnet run -- add
 dotnet run -- find
 dotnet run -- remove
+dotnet run -- mark-read
 dotnet run -- help
 ```
 

--- a/samples/book-app-project-cs/Services/BookCollection.cs
+++ b/samples/book-app-project-cs/Services/BookCollection.cs
@@ -56,6 +56,11 @@ public class BookCollection
 
     public List<Book> ListBooks() => _books;
 
+    public List<Book> GetUnreadBooks()
+    {
+        return _books.Where(b => !b.Read).ToList();
+    }
+
     public Book? FindBookByTitle(string title)
     {
         return _books.Find(b => b.Title.Equals(title, StringComparison.OrdinalIgnoreCase));

--- a/samples/book-app-project-cs/Tests/BookCollectionTests.cs
+++ b/samples/book-app-project-cs/Tests/BookCollectionTests.cs
@@ -67,4 +67,52 @@ public class BookCollectionTests : IDisposable
         var result = _collection.RemoveBook("Nonexistent Book");
         Assert.False(result);
     }
+
+    [Fact]
+    public void GetUnreadBooks_ShouldReturnOnlyUnreadBooks()
+    {
+        _collection.AddBook("The Hobbit", "J.R.R. Tolkien", 1937);
+        _collection.AddBook("1984", "George Orwell", 1949);
+        _collection.AddBook("Dune", "Frank Herbert", 1965);
+        _collection.MarkAsRead("1984");
+
+        var unread = _collection.GetUnreadBooks();
+
+        Assert.Equal(2, unread.Count);
+        Assert.All(unread, b => Assert.False(b.Read));
+        Assert.Contains(unread, b => b.Title == "The Hobbit");
+        Assert.Contains(unread, b => b.Title == "Dune");
+        Assert.DoesNotContain(unread, b => b.Title == "1984");
+    }
+
+    [Fact]
+    public void GetUnreadBooks_EmptyCollection_ShouldReturnEmpty()
+    {
+        var unread = _collection.GetUnreadBooks();
+        Assert.Empty(unread);
+    }
+
+    [Fact]
+    public void GetUnreadBooks_AllRead_ShouldReturnEmpty()
+    {
+        _collection.AddBook("The Hobbit", "J.R.R. Tolkien", 1937);
+        _collection.AddBook("Dune", "Frank Herbert", 1965);
+        _collection.MarkAsRead("The Hobbit");
+        _collection.MarkAsRead("Dune");
+
+        var unread = _collection.GetUnreadBooks();
+
+        Assert.Empty(unread);
+    }
+
+    [Fact]
+    public void GetUnreadBooks_AllUnread_ShouldReturnAll()
+    {
+        _collection.AddBook("The Hobbit", "J.R.R. Tolkien", 1937);
+        _collection.AddBook("Dune", "Frank Herbert", 1965);
+
+        var unread = _collection.GetUnreadBooks();
+
+        Assert.Equal(2, unread.Count);
+    }
 }


### PR DESCRIPTION
## Summary

Adds two CLI commands to the C# book app sample (`samples/book-app-project-cs/`): `list-unread` and `mark-read`. Together they round out the read-status workflow, so users can filter to unread books and mark a book as read directly from the command line.

## What changed

- **`Services/BookCollection.cs`**: new `GetUnreadBooks()` returning books where `Read == false` (LINQ `Where(...).ToList()`, mirroring the existing `FindByAuthor`).
- **`Program.cs`**:
  - `list-unread` command: new `HandleListUnread()` plus switch case; shows only unread books.
  - `mark-read` command: new `HandleMarkRead()` plus switch case; wires up the existing `MarkAsRead()` service method, which was previously unreachable from the CLI.
  - `ShowBooks` now accepts an optional empty-state message, so an all-read collection shows "No unread books found." instead of the generic message.
  - Help text updated for both commands.
- **`Tests/BookCollectionTests.cs`**: 4 new xUnit tests for `GetUnreadBooks` (mixed set, empty collection, all read, all unread), following the existing temp-file and `IDisposable` pattern.
- **`README.md`**: documented both new commands.

## Testing done

- `dotnet build`: passes (exit code 0).
- `dotnet test`: 9/9 pass (5 existing + 4 new).
- Manual smoke test: `list-unread` correctly excludes read books; `mark-read` handles both the found ("Book marked as read.") and not-found ("No book found with title ...") paths; `list-unread` reflects a freshly marked book.
