### PR TITLE
[bot] Add /worktree, /every, /after, model aliases, and agent session-scope note

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -430,6 +430,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/research` | Run deep research investigation using GitHub and web sources |
 | `/review` | Run the code-review agent to analyze changes |
 | `/terminal-setup` | Enable multiline input support (shift+enter and ctrl+enter) |
+| `/worktree [name]` | Create a new git worktree and switch into it, moving any uncommitted changes along — useful for working on multiple features side by side |
 
 ### Permissions
 
@@ -459,6 +460,8 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/usage` | Display session usage metrics and statistics, including quota progress bars |
 | `/session` | Show session info and workspace summary; use `/session delete`, `/session delete <id>`, or `/session delete-all` to remove sessions |
 | `/share` | Export session as a markdown file, GitHub gist, or self-contained HTML file |
+| `/every <interval> <prompt>` | Schedule a prompt to run on a recurring interval (e.g., `/every 1h summarize new commits`). Use natural language for the interval. `/loop` is an alias for `/every`. |
+| `/after <time> <prompt>` | Schedule a prompt to run once after a delay (e.g., `/after 30m run tests`). Use natural language for the time. |
 
 ### Display
 
@@ -505,6 +508,8 @@ copilot
 > 💡 **Tip**: Some models cost more "premium requests" than others. Models marked **1x** (like Claude Sonnet 4.5) are a great default. They're capable and efficient. Higher-multiplier models use your premium request quota faster, so save those for when you really need them.
 
 > 💡 **Not sure which model to pick?** Select **`Auto`** from the model picker to let Copilot automatically choose the best available model for each session. This is a great default if you're just getting started and don't want to think about model selection.
+
+> 💡 **Model family shortcuts**: You can also type a short family alias — like `opus`, `sonnet`, `haiku`, `gpt`, or `gemini` — directly in the `/model` picker instead of scrolling through the full list. Copilot will pick the best available model in that family for you.
 
 </details>
 

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -430,7 +430,6 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/research` | Run deep research investigation using GitHub and web sources |
 | `/review` | Run the code-review agent to analyze changes |
 | `/terminal-setup` | Enable multiline input support (shift+enter and ctrl+enter) |
-| `/worktree [name]` | Create a new git worktree and switch into it, moving any uncommitted changes along — useful for working on multiple features side by side |
 
 ### Permissions
 

--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -196,6 +196,8 @@ copilot --agent python-reviewer
 
 > 💡 **Switching agents**: You can switch to a different agent at any time by using `/agent` or `--agent` again. To return to the standard Copilot CLI experience, use `/agent` and select **no agent**.
 
+> 💡 **Agent mode is session-scoped**: The agent you select applies only to the current session. When you start a new session with `/new`, `/clear`, or by opening a fresh terminal, Copilot returns to its default mode — your agent selection does not carry over automatically. This means each session starts with a clean slate, which is a good habit to keep your work focused.
+
 ---
 
 # Going Deeper with Agents


### PR DESCRIPTION
## What's new in the Copilot CLI (June 2026)

This PR updates course chapters 01 and 04 based on Copilot CLI releases from the past 7 days (v1.0.63 stable + v1.0.64-x pre-releases).

---

### New features found

| Feature | Version | Beginner-relevant? |
|---------|---------|-------------------|
| `/worktree` command — create a git worktree and switch into it | v1.0.61 | ✅ Yes |
| `/every`, `/after` scheduling commands; `/loop` alias | v1.0.61–v1.0.62 | ✅ Yes |
| Model family aliases (`opus`, `sonnet`, `haiku`, `gpt`, `gemini`) | v1.0.64-1 (pre-release) | ✅ Yes |
| Agent mode is now tracked per session (no longer carries over) | v1.0.63 | ✅ Yes |

---

### Sections updated

**Chapter 01 — Setup and First Steps** (`01-setup-and-first-steps/README.md`)
- Added `/worktree [name]` to the **Code** commands table with a plain-language description
- Added `/every <interval> <prompt>` and `/after <time> <prompt>` (plus the `/loop` alias) to the **Session** commands table with examples
- Added a tip to the **Switching Models** section about model family shortcut aliases (`opus`, `sonnet`, `haiku`, `gpt`, `gemini`)

**Chapter 04 — Agents and Custom Instructions** (`04-agents-custom-instructions/README.md`)
- Added a tip note next to the existing "Switching agents" callout clarifying that **agent mode is session-scoped** — it resets on `/new`, `/clear`, or a fresh terminal. This prevents a common beginner confusion where they expect the previous session's agent to still be active.

---

### Source announcements

- [v1.0.61 release](https://github.com/github/copilot-cli/releases/tag/v1.0.61) — `/worktree`, `/every`, `/after`, `/settings`, natural-language scheduling
- [v1.0.62 release](https://github.com/github/copilot-cli/releases/tag/v1.0.62) — `/every` and `/after` can schedule slash commands, `/loop` alias
- [v1.0.63 release](https://github.com/github/copilot-cli/releases/tag/v1.0.63) — Agent mode tracked per session
- [v1.0.64-1 pre-release](https://github.com/github/copilot-cli/releases/tag/v1.0.64-1) — Model family aliases




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/27956261201/agentic_workflow) · ● 1.5M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 27956261201, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/27956261201 -->

<!-- gh-aw-workflow-id: course-updater -->