### PR TITLE
[bot] Add copilot skill CLI command, /branch alias, and argument-hint frontmatter (v1.0.64–1.0.65)

### DIFF
--- a/03-development-workflows/README.md
+++ b/03-development-workflows/README.md
@@ -718,10 +718,10 @@ copilot
 # Now you're in a new session copy. Try your alternative approach:
 > Fix find_by_author using a different regex-based strategy
 
-# If you don't like the result, switch back to your original session
+# If you don't like the result, switch back to your original session using /session
 ```
 
-> 💡 **`/branch` and `/fork` are the same**: Both commands do identical things. `/branch` was added as a more intuitive name — use whichever makes more sense to you.
+> 💡 **`/branch` and `/fork` are the same**: Both commands do identical things. `/branch` was added as a more intuitive name. Use whichever makes more sense to you.
 
 > 💡 **When to branch**: Branching is great when you're unsure which approach is better and want to keep both options open.
 

--- a/03-development-workflows/README.md
+++ b/03-development-workflows/README.md
@@ -582,7 +582,7 @@ copilot
 
 <a id="workflow-5-git-integration"></a>
 <details>
-<summary><strong>Workflow 5: Git Integration</strong> - Commit messages, PR descriptions, /pr, /delegate, and /diff</summary>
+<summary><strong>Workflow 5: Git Integration</strong> - Commit messages, PR descriptions, /pr, /delegate, /diff, and /branch</summary>
 
 <img src="assets/git-integration-swimlane-single.png" alt="Git Integration workflow: stage changes, generate message, commit, create PR." width="800"/>
 
@@ -691,7 +691,7 @@ This is great for well-defined tasks you want completed while you focus on other
 
 ### Using /diff to Review Session Changes
 
-The `/diff` command shows all changes made during your current session. Use this slash command to see a visual diff of everything Copilot CLI has modified before you commit.
+The `/diff` command shows all changes made during your current session. Use this slash command to see a visual diff of everything Copilot CLI has modified before you commit. It also works in folders that aren't git repositories.
 
 ```bash
 copilot
@@ -702,6 +702,28 @@ copilot
 # Shows a visual diff of all files modified in this session
 # Great for reviewing before committing
 ```
+
+### Branching Your Session with /branch or /fork
+
+Sometimes you want to explore two different approaches to a problem without losing your original conversation. The `/branch` command (also available as `/fork`) creates a copy of your current session so you can try a different direction and then compare results.
+
+```bash
+copilot
+
+> Fix the find_by_author function to support partial matches
+
+# You want to try a different approach — branch first!
+> /branch
+
+# Now you're in a new session copy. Try your alternative approach:
+> Fix find_by_author using a different regex-based strategy
+
+# If you don't like the result, switch back to your original session
+```
+
+> 💡 **`/branch` and `/fork` are the same**: Both commands do identical things. `/branch` was added as a more intuitive name — use whichever makes more sense to you.
+
+> 💡 **When to branch**: Branching is great when you're unsure which approach is better and want to keep both options open.
 
 </details>
 

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -492,7 +492,7 @@ Discover installed skills, find community skills, and share your own.
 
 ## Managing Skills with the `copilot skill` Command and `/skills`
 
-Copilot CLI gives you two ways to manage skills — one from your terminal before starting Copilot, and one from inside a Copilot session.
+Copilot CLI gives you two ways to manage skills. You can do it directly from the terminal before starting Copilot or from inside a Copilot session.
 
 ### Option 1: `copilot skill` (Terminal Command)
 

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -369,6 +369,9 @@ Provide issues as a numbered list with severity:
 | `name` | **Yes** | Unique identifier (lowercase, hyphens for spaces) |
 | `description` | **Yes** | What the skill does and when Copilot should use it |
 | `license` | No | License that applies to this skill |
+| `argument-hint` | No | Short hint shown to users describing what argument the skill expects (e.g., `"file path or code snippet"`) |
+
+> 💡 **What is `argument-hint`?** When users invoke a skill directly (e.g., `/security-audit`), the `argument-hint` text appears as a placeholder showing what to type next — like a mini help prompt. For example, setting `argument-hint: "file path to review"` tells the user to provide a file path after the skill name.
 
 > 📖 **Official docs**: [About Agent Skills](https://docs.github.com/copilot/concepts/agents/about-agent-skills)
 
@@ -487,9 +490,29 @@ Discover installed skills, find community skills, and share your own.
 
 ---
 
-## Managing Skills with the `/skills` Command
+## Managing Skills with the `copilot skill` Command and `/skills`
 
-Use the `/skills` command to manage your installed skills:
+Copilot CLI gives you two ways to manage skills — one from your terminal before starting Copilot, and one from inside a Copilot session.
+
+### Option 1: `copilot skill` (Terminal Command)
+
+The `copilot skill` subcommand lets you manage skills directly from your terminal, without opening an interactive Copilot session. This is handy for scripting, quick checks, or adding skills before you start working.
+
+```bash
+# See all installed skills
+copilot skill list
+
+# Add a skill from a local file, URL, or directory
+copilot skill add .github/skills/my-skill/SKILL.md
+copilot skill add https://example.com/skills/security-audit/SKILL.md
+
+# Remove a skill by name
+copilot skill remove security-audit
+```
+
+### Option 2: `/skills` (Inside Copilot Session)
+
+Once you're in an interactive Copilot session, use `/skills` (or its shortcut `/skill`) to manage skills without leaving:
 
 | Command | What It Does |
 |---------|--------------|
@@ -499,11 +522,23 @@ Use the `/skills` command to manage your installed skills:
 | `/skills remove <name>` | Disable or uninstall a skill |
 | `/skills reload` | Reload skills after editing SKILL.md files |
 
+> 💡 **`/skill` shortcut**: You can type `/skill` instead of `/skills` — they're interchangeable. For example, `/skill list` works the same as `/skills list`.
+
 > 💡 **Remember**: You don't need to "activate" skills for each prompt. Once installed, skills are **automatically triggered** when your prompt matches their description. These commands are for managing which skills are available, not for using them.
 
 ### Example: View Your Skills
 
 ```bash
+# From the terminal (no interactive session needed):
+copilot skill list
+
+Available skills:
+- security-audit: Security-focused code review checking OWASP Top 10
+- generate-tests: Generate comprehensive unit tests with edge cases
+- code-checklist: Team code quality checklist
+...
+
+# Or from inside a Copilot session:
 copilot
 
 > /skills list
@@ -873,9 +908,10 @@ Run `/skills reload` after creating or editing skills to ensure changes are pick
 
 1. **Skills are automatic**: Copilot loads them when your prompt matches the skill's description
 2. **Direct invocation**: You can also invoke skills directly with `/skill-name` as a slash command
-3. **SKILL.md format**: YAML frontmatter (name, description, optional license) plus markdown instructions
+3. **SKILL.md format**: YAML frontmatter (name, description, optional license, argument-hint) plus markdown instructions
 4. **Location matters**: `.github/skills/` for project/team sharing, `~/.copilot/skills/` for personal use
 5. **Description is key**: Write descriptions that match how you naturally ask questions
+6. **Two ways to manage skills**: Use `copilot skill` from the terminal or `/skills` (shortcut: `/skill`) inside a session
 
 > 📋 **Quick Reference**: See the [GitHub Copilot CLI command reference](https://docs.github.com/en/copilot/reference/cli-command-reference) for a complete list of commands and shortcuts.
 


### PR DESCRIPTION
## What's New in Copilot CLI

This PR updates course content based on Copilot CLI releases **v1.0.64** (2026-06-23) and **v1.0.65** (2026-06-24).

---

## New Features Found

### v1.0.65
- **`copilot skill` CLI subcommand** — Manage skills (list, add, remove) directly from the terminal without opening an interactive Copilot session
- **`/skill` alias for `/skills`** — Shortcut so you can type `/skill list` instead of `/skills list` inside a session
- `/cd` now persists working directory on session resume (advanced — not included)

### v1.0.64
- **`argument-hint` frontmatter** for skills — Lets skill authors show a short hint to users about what argument to provide when directly invoking a skill (e.g., `/security-audit <file path>`)
- **`/branch` as alias for `/fork`** — Creates a copy of the current session so you can explore a different approach without losing your original work
- `/diff` now works in non-git folders

---

## Course Sections Updated

### Chapter 05 — Skills (`05-skills/README.md`)
- Replaced the single "Managing Skills with `/skills`" section with a new dual-method section showing **`copilot skill` (terminal)** and **`/skills` (in-session)**, including `copilot skill list/add/remove` examples
- Added `/skill` as a documented alias for `/skills`
- Added `argument-hint` to the SKILL.md YAML Properties table with a beginner-friendly explanation of what it does
- Updated the Example section to show both the terminal and in-session workflows
- Updated Key Takeaways to reflect both skill management methods

### Chapter 03 — Development Workflows (`03-development-workflows/README.md`)
- Added a new **"Branching Your Session with /branch or /fork"** subsection inside Workflow 5 (Git Integration), explaining how to explore multiple solutions in parallel
- Updated `/diff` description to note it now works in non-git folders
- Updated the Workflow 5 summary line to include `/branch`

---

## Source Announcements

- [Copilot CLI v1.0.65 changelog](https://github.com/github/copilot-cli/blob/main/changelog.md) — 2026-06-24
- [Copilot CLI v1.0.64 changelog](https://github.com/github/copilot-cli/blob/main/changelog.md) — 2026-06-23




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/28373753784/agentic_workflow) · ● 1.4M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 28373753784, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/28373753784 -->

<!-- gh-aw-workflow-id: course-updater -->