### PR TITLE
[bot] Add /mcp list command and @-style imports for instruction files

### DIFF
--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -486,6 +486,22 @@ Here are some common patterns:
 
 > 💡 **Tip**: Wrap the glob pattern in quotes (e.g., `"**/*.py"`) to ensure it is interpreted correctly across all operating systems and shells.
 
+#### Importing Other Files with `@`
+
+You can reference another file inside `AGENTS.md` or any instruction file using `@filepath` syntax. Copilot expands the reference and includes that file's content automatically, so you can keep your main file short while storing the details elsewhere:
+
+```markdown
+<!-- AGENTS.md -->
+# Project Instructions
+
+@.github/instructions/python-standards.instructions.md
+@.github/instructions/test-standards.instructions.md
+```
+
+This is handy when your instructions grow large. Split them into focused files and `@`-import them from a single `AGENTS.md`. The same syntax works inside `.github/copilot-instructions.md` and other instruction files too.
+
+> 💡 **Tip**: Use `@`-imports to share a common base file across multiple instruction files. For example, you could have a `@.github/instructions/shared-rules.md` that every other instruction file pulls in.
+
 **Finding community instruction files**: Browse [github/awesome-copilot](https://github.com/github/awesome-copilot) for pre-made instruction files covering .NET, Angular, Azure, Python, Docker, and many more technologies.
 
 ### Disabling Custom Instructions

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -924,6 +924,7 @@ These work when you're already inside `copilot`:
 | Command | What It Does |
 |---------|--------------|
 | `/mcp show` | Show all configured MCP servers and their status |
+| `/mcp list` | Show currently attached MCP servers and their status; can be run while Copilot is working |
 | `/mcp add` | Interactive setup for adding a new server |
 | `/mcp edit <server-name>` | Edit an existing server configuration |
 | `/mcp enable <server-name>` | Enable a disabled server (persists across sessions) |


### PR DESCRIPTION
## What's New in the Copilot CLI

The following beginner-relevant features were released in the past 7 days and are now documented in the course:

### 1. `/mcp list` slash command — v1.0.69-1 (2026-07-04)

A new `/mcp list` slash command was added that shows **currently attached** MCP servers and their status. Unlike `/mcp show` (which lists all configured servers), `/mcp list` focuses on the servers actively attached to your session. It can also be run while Copilot is in the middle of a task.

### 2. `@`-style imports in instruction files — v1.0.66 (2026-06-30)

AGENTS.md, `.github/copilot-instructions.md`, and other instruction files now support `@filepath` syntax to include content from other files. This lets teams keep a short top-level `AGENTS.md` that references focused instruction files rather than cramming everything into one long file.

---

## Course Sections Updated

| Chapter | Section | Change |
|---------|---------|--------|
| **Chapter 06 — MCP Servers** | Additional MCP Commands → slash commands table | Added `/mcp list` row with description |
| **Chapter 04 — Agents & Custom Instructions** | Custom Instruction Files | Added new "Importing Other Files with `@`" section with example and tip |

---

## Source Announcements

- [`v1.0.69-1` release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.69-1) — `/mcp list` command
- [`v1.0.66` release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.66) — `@-style imports in AGENTS.md, CLAUDE.md, and Copilot instruction files`




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/28793041772/agentic_workflow) · ● 736.7K · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 28793041772, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/28793041772 -->

<!-- gh-aw-workflow-id: course-updater -->