### PR TITLE
[bot] Add /refine command and /plugins dashboard documentation

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -410,7 +410,6 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/env` | Show loaded environment details — what instructions, MCP servers, skills, agents, and plugins are active |
 | `/init` | Initialize Copilot instructions for your repository |
 | `/mcp` | Manage MCP server configuration |
-| `/plugins` | Open the plugins dashboard to view and manage installed plugins |
 | `/settings` | Open an interactive dialog to browse and edit all user settings in one place |
 | `/skills` | Manage skills for enhanced capabilities |
 

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -383,10 +383,13 @@ These commands are great to learn initially as you're getting started with Copil
 | `/help` | Show all available commands | When you forget a command |
 | `/model` | Show or switch AI model | When you want to change the AI model |
 | `/plan` | Plan your work out before coding | For more complex features |
+| `/refine` | Rewrite a rough, stream-of-consciousness prompt into a clear, focused one | When your prompt feels messy and you want better results |
 | `/research` | Deep research using GitHub and web sources | When you need to investigate a topic before coding |
 | `/exit` | End the session | When you're done |
 
 > 💡 **`/ask` vs regular chat**: Normally every message you send becomes part of the ongoing conversation and affects future responses. `/ask` is an "off the record" shortcut — perfect for quick one-off questions like `/ask What does YAML mean?` without polluting your session context.
+
+> 💡 **`/refine` for better prompts**: Not sure if your prompt is clear enough? Type it out as it comes to mind, then run `/refine` to let Copilot rewrite it into a precise, well-structured prompt before sending. This is especially useful when you're new to AI tools and still learning how to write effective prompts.
 
 > 💡 **Tab-completion**: When typing a slash command, press **Tab** to auto-complete the command name or cycle through available subcommands and arguments. This is especially handy when you can't remember the exact name of a command.
 
@@ -407,6 +410,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/env` | Show loaded environment details — what instructions, MCP servers, skills, agents, and plugins are active |
 | `/init` | Initialize Copilot instructions for your repository |
 | `/mcp` | Manage MCP server configuration |
+| `/plugins` | Open the plugins dashboard to view and manage installed plugins |
 | `/settings` | Open an interactive dialog to browse and edit all user settings in one place |
 | `/skills` | Manage skills for enhanced capabilities |
 

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -288,8 +288,6 @@ This adds the server and its associated agent skills automatically. The skills i
 - **microsoft-code-reference**: API lookups, code samples, and troubleshooting
 - **microsoft-skill-creator**: A meta-skill for generating custom skills about Microsoft technologies
 
-> 💡 **Managing installed plugins**: After installing plugins, use `/plugins` to open the plugins dashboard. From there you can view, enable, disable, or remove any installed plugin — no need to edit config files manually.
-
 **Usage:**
 ```bash
 copilot

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -288,6 +288,8 @@ This adds the server and its associated agent skills automatically. The skills i
 - **microsoft-code-reference**: API lookups, code samples, and troubleshooting
 - **microsoft-skill-creator**: A meta-skill for generating custom skills about Microsoft technologies
 
+> 💡 **Managing installed plugins**: After installing plugins, use `/plugins` to open the plugins dashboard. From there you can view, enable, disable, or remove any installed plugin — no need to edit config files manually.
+
 **Usage:**
 ```bash
 copilot


### PR DESCRIPTION
## What's New

Two beginner-friendly features shipped in the past 7 days and were missing from the course:

### 1. `/refine` command (v1.0.70, released 2026-07-10)
Rewrites a rough, stream-of-consciousness prompt into a clear, focused one. This is highly valuable for beginners who are still learning to write effective AI prompts — they can just type their thoughts and let `/refine` polish the prompt before sending.

### 2. `/plugins` dashboard (v1.0.69, released 2026-07-07)
An interactive dashboard to view and manage all installed plugins. Complements the existing `/plugin install` workflow documented in Chapter 06.

## What Was Updated

### Chapter 01 — Setup and First Steps
- Added `/refine` to the **Essential Slash Commands** table with a beginner-friendly "when to use" description
- Added a `💡` tip callout explaining the `/refine` workflow for beginners new to prompt writing
- Added `/plugins` to the **Agent Environment** commands reference table

### Chapter 06 — MCP Servers
- Added a `💡` tip near the `/plugin install` example pointing learners to `/plugins` for managing installed plugins

## Source Announcements
- [`v1.0.70` release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.70) — `/refine` added
- [`v1.0.69` release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.69) — `/plugins` dashboard added




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/29249914217/agentic_workflow) · ● 1.4M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 29249914217, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/29249914217 -->

<!-- gh-aw-workflow-id: course-updater -->