### PR TITLE
[bot] docs: update course content with Copilot CLI v1.0.71–v1.0.72 features

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -325,7 +325,7 @@ Step 4: Test the flow
 Proceed with implementation? [Y/n]
 ```
 
-**Key insight**: Plan mode lets you review and modify the approach before any code is written. Once a plan is complete, you can even tell Copilot CLI to save it to a file for later reference. For example, "Save this plan to `mark_as_read_plan.md`" would create a markdown file with the plan details.
+**Key insight**: Plan mode lets you review and modify the approach before any code is written. While in plan mode, Copilot CLI is **read-only** — it will not edit any files or run commands that change your workspace until you approve and move to implementation. This keeps you safely in the "thinking" stage until you're ready. Once a plan is complete, you can even tell Copilot CLI to save it to a file for later reference. For example, "Save this plan to `mark_as_read_plan.md`" would create a markdown file with the plan details.
 
 > 💡 **Want something more complex?** Try: `/plan Add search and filter capabilities to the book app`. Plan mode scales from simple features to full applications.
 

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -325,7 +325,7 @@ Step 4: Test the flow
 Proceed with implementation? [Y/n]
 ```
 
-**Key insight**: Plan mode lets you review and modify the approach before any code is written. While in plan mode, Copilot CLI is **read-only** — it will not edit any files or run commands that change your workspace until you approve and move to implementation. This keeps you safely in the "thinking" stage until you're ready. Once a plan is complete, you can even tell Copilot CLI to save it to a file for later reference. For example, "Save this plan to `mark_as_read_plan.md`" would create a markdown file with the plan details.
+**Key insight**: Plan mode lets you review and modify the approach before any code is written. While in plan mode, Copilot CLI is **read-only** and will not edit any files or run commands that change your workspace until you approve and move to implementation. This keeps you safely in the "thinking" stage until you're ready. Once a plan is complete, you can even tell Copilot CLI to save it to a file for later reference. For example, "Save this plan to `mark_as_read_plan.md`" would create a markdown file with the plan details.
 
 > 💡 **Want something more complex?** Try: `/plan Add search and filter capabilities to the book app`. Plan mode scales from simple features to full applications.
 

--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -107,6 +107,7 @@ What about the Task Agent? It works behind the scenes to manage and track what i
 | ✅ **Success** | Brief summary (e.g., "All 247 tests passed", "Build succeeded") |
 | ❌ **Failure** | Full output with stack traces, compiler errors, and detailed logs |
 
+> 💡 **Multi-turn subagents**: Subagents (background tasks launched by agents) support follow-up messages. While an agent is running in the background, you can open `/tasks` to view it and send follow-up instructions — you don't have to wait for it to finish before guiding it further. Think of it like being able to tap your assistant on the shoulder mid-task to give extra direction.
 
 > 📚 **Official Documentation**: [GitHub Copilot CLI Agents](https://docs.github.com/copilot/how-tos/use-copilot-agents/use-copilot-cli#use-custom-agents)
 

--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -107,7 +107,7 @@ What about the Task Agent? It works behind the scenes to manage and track what i
 | ✅ **Success** | Brief summary (e.g., "All 247 tests passed", "Build succeeded") |
 | ❌ **Failure** | Full output with stack traces, compiler errors, and detailed logs |
 
-> 💡 **Multi-turn subagents**: Subagents (background tasks launched by agents) support follow-up messages. While an agent is running in the background, you can open `/tasks` to view it and send follow-up instructions — you don't have to wait for it to finish before guiding it further. Think of it like being able to tap your assistant on the shoulder mid-task to give extra direction.
+> 💡 **Multi-turn subagents**: Subagents (background tasks launched by agents) support follow-up messages. While an agent is running in the background, you can open `/tasks` to view it and send follow-up instructions. You don't have to wait for it to finish before guiding it further. Think of it like being able to tap your assistant on the shoulder mid-task to give extra direction.
 
 > 📚 **Official Documentation**: [GitHub Copilot CLI Agents](https://docs.github.com/copilot/how-tos/use-copilot-agents/use-copilot-cli#use-custom-agents)
 

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -535,7 +535,7 @@ copilot skill list
 Available skills:
 - security-audit: Security-focused code review checking OWASP Top 10
 - generate-tests: Generate comprehensive unit tests with edge cases
-- code-checklist: Team code quality checklist
+- code-checklist: Team code quality checklist [disabled]
 ...
 
 # Or from inside a Copilot session:
@@ -546,7 +546,7 @@ copilot
 Available skills:
 - security-audit: Security-focused code review checking OWASP Top 10
 - generate-tests: Generate comprehensive unit tests with edge cases
-- code-checklist: Team code quality checklist
+- code-checklist: Team code quality checklist [disabled]
 ...
 
 > /skills info security-audit
@@ -556,6 +556,8 @@ Source: Project
 Location: .github/skills/security-audit/SKILL.md
 Description: Security-focused code review checking OWASP Top 10 vulnerabilities
 ```
+
+> 💡 **Disabled skills**: Skills marked as `[disabled]` are installed but not currently active. They won't be triggered by prompts until re-enabled. This can happen if a skill's `SKILL.md` file has a configuration issue, or if the skill was explicitly disabled.
 
 ---
 

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -532,10 +532,10 @@ Once you're in an interactive Copilot session, use `/skills` (or its shortcut `/
 # From the terminal (no interactive session needed):
 copilot skill list
 
-Available skills:
+Project skills:
 - security-audit: Security-focused code review checking OWASP Top 10
 - generate-tests: Generate comprehensive unit tests with edge cases
-- code-checklist: Team code quality checklist [disabled]
+- code-checklist: Team code quality checklist (disabled)
 ...
 
 # Or from inside a Copilot session:
@@ -543,10 +543,10 @@ copilot
 
 > /skills list
 
-Available skills:
+Project skills:
 - security-audit: Security-focused code review checking OWASP Top 10
 - generate-tests: Generate comprehensive unit tests with edge cases
-- code-checklist: Team code quality checklist [disabled]
+- code-checklist: Team code quality checklist (disabled)
 ...
 
 > /skills info security-audit
@@ -557,7 +557,7 @@ Location: .github/skills/security-audit/SKILL.md
 Description: Security-focused code review checking OWASP Top 10 vulnerabilities
 ```
 
-> 💡 **Disabled skills**: Skills marked as `[disabled]` are installed but not currently active. They won't be triggered by prompts until re-enabled. This can happen if a skill's `SKILL.md` file has a configuration issue, or if the skill was explicitly disabled.
+> 💡 **Disabled skills**: Skills marked as `(disabled)` are installed but not currently active. They won't be triggered by prompts until re-enabled. This can happen if a skill's `SKILL.md` file has a configuration issue, or if the skill was explicitly disabled. You can enable/disable skills by running `/skills`.
 
 ---
 


### PR DESCRIPTION
## What's new in Copilot CLI (v1.0.71–v1.0.72, July 13–20 2026)

Three beginner-relevant changes were identified in the Copilot CLI releases published in the past 7 days and added to the course.

---

### 1. Plan mode now hard-blocks file edits (v1.0.71-2)

**Release**: [v1.0.71-2](https://github.com/github/copilot-cli/releases/tag/v1.0.71-2) (July 15, 2026)

> Plan mode now hard-blocks built-in tool calls that would modify the workspace, so the agent can no longer edit files or run mutating shell commands while planning.

**Section updated**: Chapter 01 — Mode 2: Plan Mode (`01-setup-and-first-steps/README.md`)

The "Key insight" paragraph now explicitly tells beginners that plan mode is **read-only** and won't touch their files until they approve. This removes a common worry for new users who aren't sure if Copilot will change their code immediately.

---

### 2. Multi-turn subagents are always enabled (v1.0.72-0)

**Release**: [v1.0.72-0](https://github.com/github/copilot-cli/releases/tag/v1.0.72-0) (July 16, 2026)

> Multi-turn subagents are always enabled, so you can send follow-up messages to running agents.

**Section updated**: Chapter 04 — Built-in Agents (`04-agents-custom-instructions/README.md`)

Added a new tip after the Task Agent table explaining that beginners can now open `/tasks` to send follow-up instructions to a running background agent — without waiting for it to finish.

---

### 3. `copilot skill list` marks disabled skills (v1.0.71-2)

**Release**: [v1.0.71-2](https://github.com/github/copilot-cli/releases/tag/v1.0.71-2) (July 15, 2026)

> Mark disabled skills in `copilot skill list` and its JSON output.

**Section updated**: Chapter 05 — Example: View Your Skills (`05-skills/README.md`)

Updated the `copilot skill list` code example to show a skill with a `[disabled]` label, and added a tip explaining what disabled skills are and why they appear.

---

## Source announcements

- https://github.com/github/copilot-cli/releases/tag/v1.0.71-2
- https://github.com/github/copilot-cli/releases/tag/v1.0.72-0
- https://github.com/github/copilot-cli/releases/tag/v1.0.72-1




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/29742032072/agentic_workflow) · ● 728.6K · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 29742032072, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/29742032072 -->

<!-- gh-aw-workflow-id: course-updater -->