### PR TITLE
[bot] Update login flow docs and add /permissions, /plugins commands (v1.0.76–v1.0.78)

### DIFF
--- a/00-quick-start/README.md
+++ b/00-quick-start/README.md
@@ -143,17 +143,19 @@ After trusting the folder, you can sign in with your GitHub account.
 > /login
 ```
 
-**What happens next:**
+**What happens next (local terminal):**
 
-1. Copilot CLI displays a one-time code (like `ABCD-1234`)
-2. Your browser opens to GitHub's device authorization page. Sign in to GitHub if you haven't already.
-3. Enter the code when prompted
-4. Select "Authorize" to grant GitHub Copilot CLI access
-5. Return to your terminal - you're now signed in!
+1. Your browser opens automatically to GitHub's authorization page. Sign in to GitHub if you haven't already.
+2. Select "Authorize" to grant GitHub Copilot CLI access.
+3. Return to your terminal — you're now signed in!
+
+> 💡 **Remote or headless terminals**: If you're on a remote server or a terminal without a browser (such as SSH), Copilot CLI falls back to the **device code flow** instead. You'll see a one-time code (like `ABCD-1234`) — visit [github.com/login/device](https://github.com/login/device) in a browser and enter the code to complete sign-in.
+
+> 💡 **Force a specific flow**: Use `--web-flow` to always use the browser popup, or `--device-code` to always use the code-based flow. You can also pick interactively with `/login`.
 
 <img src="assets/auth-device-flow.png" alt="Device Authorization Flow - showing the 5-step process from terminal login to signed-in confirmation" width="800"/>
 
-*The device authorization flow: your terminal generates a code, you verify it in the browser, and Copilot CLI is authenticated.*
+*The browser-based flow: your browser opens automatically and you authorize in one click. On remote/headless terminals, a device code is shown instead.*
 
 **Tip**: The sign-in persists across sessions. You only need to do this once unless your token expires or you explicitly sign out.
 
@@ -267,7 +269,7 @@ copilot
 
 ### Browser doesn't open automatically
 
-Manually visit [github.com/login/device](https://github.com/login/device) and enter the code shown in your terminal.
+On remote or headless terminals, the device code flow is used instead. Your terminal will display a one-time code — manually visit [github.com/login/device](https://github.com/login/device) and enter it. On a local terminal, try running `/login --web-flow` to force the browser popup.
 
 ### Token expired
 

--- a/00-quick-start/README.md
+++ b/00-quick-start/README.md
@@ -270,7 +270,7 @@ copilot
 
 ### Browser doesn't open automatically
 
-On remote or headless terminals, the device code flow is used instead. Your terminal will display a one-time code — manually visit [github.com/login/device](https://github.com/login/device) and enter it. On a local terminal, try running `/login --web-flow` to force the browser popup.
+On remote or headless terminals, the device code flow is used instead. Your terminal will display a one-time code. Visit [github.com/login/device](https://github.com/login/device) and enter the code, then authorize access.
 
 ### Token expired
 

--- a/00-quick-start/README.md
+++ b/00-quick-start/README.md
@@ -145,16 +145,17 @@ After trusting the folder, you can sign in with your GitHub account.
 
 **What happens next (local terminal):**
 
-1. Your browser opens automatically to GitHub's authorization page. Sign in to GitHub if you haven't already.
-2. Select "Authorize" to grant GitHub Copilot CLI access.
-3. Return to your terminal — you're now signed in!
+1. Choose to sign into your GitHub.com account or an enterprise account.
+2. Select `Sign in with your browser (recommended)`
+3. Your browser opens automatically to GitHub's authorization page. Sign in to GitHub if you haven't already.
+4. Select "Authorize" to grant GitHub Copilot CLI access.
+5. Return to your terminal — you're now signed in!
 
-> 💡 **Remote or headless terminals**: If you're on a remote server or a terminal without a browser (such as SSH), Copilot CLI falls back to the **device code flow** instead. You'll see a one-time code (like `ABCD-1234`) — visit [github.com/login/device](https://github.com/login/device) in a browser and enter the code to complete sign-in.
-
-> 💡 **Force a specific flow**: Use `--web-flow` to always use the browser popup, or `--device-code` to always use the code-based flow. You can also pick interactively with `/login`.
-
-<img src="assets/auth-device-flow.png" alt="Device Authorization Flow - showing the 5-step process from terminal login to signed-in confirmation" width="800"/>
-
+> 💡 **Remote or headless terminals**: If you're on a remote server or a terminal without a browser (such as SSH), Copilot CLI falls back to the **device code flow** instead. You'll see a one-time code like `ABCD-1234`. Visit [github.com/login/device](https://github.com/login/device) in a browser on another machine and enter the code to complete sign-in. To force a specific flow, use `copilot login --web-flow` to use the browser popup or `copilot login --device-code` to use the code-based flow. You can also pick interactively with `/login`.
+> 
+> <img src="assets/auth-device-flow.png" alt="Device Authorization Flow - showing the 5-step process from terminal login to signed-in confirmation" width="800"/>
+>
+ 
 *The browser-based flow: your browser opens automatically and you authorize in one click. On remote/headless terminals, a device code is shown instead.*
 
 **Tip**: The sign-in persists across sessions. You only need to do this once unless your token expires or you explicitly sign out.

--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -410,6 +410,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/env` | Show loaded environment details — what instructions, MCP servers, skills, agents, and plugins are active |
 | `/init` | Initialize Copilot instructions for your repository |
 | `/mcp` | Manage MCP server configuration |
+| `/plugins` | Enable or disable plugins, instructions, agents, LSP servers, and hooks without restarting the session |
 | `/settings` | Open an interactive dialog to browse and edit all user settings in one place |
 | `/skills` | Manage skills for enhanced capabilities |
 
@@ -440,6 +441,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 |---------|--------------|
 | `/add-dir <directory>` | Add a directory to allowed list |
 | `/allow-all [on\|off\|show]` | Auto-approve all permission prompts; use `on` to enable, `off` to disable, `show` to check current status |
+| `/permissions` | Switch between approval modes (interactive, plan, autopilot) for controlling how much Copilot can do without asking |
 | `/yolo` | Quick alias for `/allow-all on` — auto-approves all permission prompts. |
 | `/cwd`, `/cd [directory]` | View or change working directory |
 | `/list-dirs` | Show all allowed directories |


### PR DESCRIPTION
## What changed in Copilot CLI

From releases **v1.0.76–v1.0.78** (July 28–31, 2026):

- **v1.0.77** — Browser-based OAuth is now the **default login flow** on local interactive terminals. The device code flow is now a fallback for remote/headless terminals. Use `--web-flow` or `--device-code` flags to force a specific mode.
- **v1.0.78-0** — New **`/permissions`** slash command to switch between approval modes.
- **v1.0.76** — New enable/disable controls in **`/plugins`** for plugins, instructions, agents, LSP servers, and hooks.

## Sections updated

### `00-quick-start/README.md`
- **Authentication section**: Updated "What happens next" to describe the browser-based OAuth flow as the default. Noted that device code is the fallback for remote/headless terminals. Added tips for `--web-flow` and `--device-code` flags.
- **Troubleshooting — "Browser doesn't open automatically"**: Rewritten to reflect the new default (browser popup on local, device code on remote), including how to force the browser flow with `--web-flow`.

### `01-setup-and-first-steps/README.md`
- **Additional Commands — Permissions table**: Added `/permissions` command with a beginner-friendly description.
- **Additional Commands — Agent Environment table**: Added `/plugins` command with a beginner-friendly description.

## Source announcements

- v1.0.76: https://github.com/github/copilot-cli/releases/tag/v1.0.76
- v1.0.77: https://github.com/github/copilot-cli/releases/tag/v1.0.77
- v1.0.78-0: https://github.com/github/copilot-cli/releases/tag/v1.0.78-0




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/30814629413/agentic_workflow) · ● 1.2M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 30814629413, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/30814629413 -->

<!-- gh-aw-workflow-id: course-updater -->