### PR TITLE
[bot] Update /rewind docs to reflect v1.0.78 improvements (no git required, file restore option)

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -460,7 +460,7 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/new` | Ends the current session (saving it to history for search/resume) and starts a fresh conversation. |
 | `/resume` | Switch to a different session (optionally specify session ID or name) |
 | `/rename` | Rename the current session (omit the name to auto-generate one) |
-| `/rewind` | Open a timeline picker to roll back to any earlier point in the conversation |
+| `/rewind` | Open a timeline picker to roll back to any earlier point in the conversation; optionally restores the files Copilot changed (works without git) |
 | `/usage` | Display session usage metrics and statistics, including quota progress bars |
 | `/session` | Show session info and workspace summary; use `/session delete`, `/session delete <id>`, or `/session delete-all` to remove sessions |
 | `/share` | Export session as a markdown file, GitHub gist, or self-contained HTML file |

--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -408,7 +408,7 @@ Context usage: 62k/200k tokens (31%)
 
 > 💡 **When to use `/clear` or `/new`**: If you've been reviewing books.py and want to switch to discussing utils.py, run /new first (or /clear if you don't need the session history). Otherwise stale context from the old topic may confuse responses.
 
-> 💡 **Made a mistake or want to try a different approach?** Use `/rewind` (or press Esc twice) to open a **timeline picker** that lets you roll back to any earlier point in your conversation, not just the most recent one. This is useful when you went down the wrong path and want to backtrack without starting over entirely.
+> 💡 **Made a mistake or want to try a different approach?** Use `/rewind` (or press Esc twice) to open a **timeline picker** that lets you roll back to any earlier point in your conversation, not just the most recent one. When you rewind, Copilot CLI asks whether you want to restore only the conversation or also undo the file changes Copilot made — no git repository required. This is useful when you went down the wrong path and want to backtrack without starting over entirely.
 
 ---
 
@@ -639,7 +639,7 @@ copilot
 | Situation | Action | Why |
 |-----------|--------|-----|
 | Starting new topic | `/clear` | Removes irrelevant context |
-| Went down wrong path | `/rewind` | Roll back to any earlier point |
+| Went down wrong path | `/rewind` | Roll back conversation (and optionally restore files) to any earlier point |
 | Long conversation | `/compact` | Summarizes history, frees tokens |
 | Need specific file | `@file.py` not `@folder/` | Loads only what you need |
 | Hitting limits | `/new` or `/clear` | Fresh context |


### PR DESCRIPTION
## What changed in Copilot CLI

In **v1.0.78 (2026-08-03)**, the `/rewind` command received a meaningful upgrade:

> `/rewind` no longer requires git and restores only the files Copilot changed, skipping any file whose contents no longer match what Copilot last wrote, with a **conversation-only or conversation + files** choice.

This is beginner-relevant because:
- Beginners often work outside of git repositories, so removing the git requirement makes `/rewind` accessible to more learners.
- The new "conversation-only vs conversation + files" choice gives learners more precise control when undoing Copilot's work.

## What was updated

| File | Change |
|------|--------|
| `01-setup-and-first-steps/README.md` | Updated the `/rewind` row in the slash commands reference table to mention the file restore option and that git is not required. |
| `02-context-conversations/README.md` | Updated the `/rewind` tip callout to describe the new conversation-only vs conversation + files choice, and noted that no git repository is needed. Also updated the Context Efficiency Tips table entry. |

## Source

- Changelog: https://github.com/github/copilot-cli/blob/main/changelog.md — entry for **1.0.78 (2026-08-03)**

> **Note**: The other changes in v1.0.78 (browser login flow, `/permissions`, `/plugins`) were already covered in PR #197, merged 2026-08-04. This PR addresses only the `/rewind` improvement that was missed.




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/31385548457/agentic_workflow) · ● 1M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 31385548457, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/31385548457 -->

<!-- gh-aw-workflow-id: course-updater -->