### PR TITLE
Add book app test coverage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,86 @@ These instructions guide GitHub Copilot when working in this repository.
 
 This is a **beginner-friendly educational course** teaching GitHub Copilot CLI. The repo contains Markdown chapters (00–07), Python/C#/JavaScript sample apps, and supporting assets (images, demo GIFs, glossary). It is **not** a software product — it is technical courseware.
 
+## Build, Test, and Lint Commands
+
+### Repository-level (course asset generation)
+
+```bash
+npm install
+npm run release
+```
+
+- `npm run release` runs the demo generation pipeline (`create:tapes` → `generate:vhs` → `verify:gifs`).
+- CI-friendly command:
+
+```bash
+npm run release:ci
+```
+
+### Primary sample app (Python)
+
+```bash
+cd samples/book-app-project
+python book_app.py help
+python -m pytest tests/
+python -m pytest tests/test_books.py::test_add_book
+```
+
+### JavaScript sample app
+
+```bash
+cd samples/book-app-project-js
+npm test
+node --test --test-name-pattern="should add a book" tests/test_books.js
+```
+
+### C# sample app
+
+```bash
+cd samples/book-app-project-cs
+dotnet run -- help
+cd Tests
+dotnet test
+dotnet test --filter "AddBook_ShouldAddAndPersist"
+```
+
+### Linting
+
+No dedicated lint command is currently defined in root `package.json` or sample app manifests.
+
+## High-Level Architecture
+
+### 1) Course content layer
+
+- Chapters `00-quick-start` through `07-putting-it-together` are the main curriculum.
+- Each chapter is a standalone `README.md` with images/GIF demos in that chapter’s `images/` folder.
+- Root `README.md` is the course entrypoint and links all chapters as the learning path.
+
+### 2) Sample application layer
+
+- `samples/book-app-project/` (Python) is the canonical sample used throughout the course.
+- Parallel implementations exist in:
+  - `samples/book-app-project-js/` (Node.js)
+  - `samples/book-app-project-cs/` (C#/.NET)
+- In each variant, architecture is intentionally simple:
+  - CLI entrypoint (`book_app.py`, `book_app.js`, `Program.cs`)
+  - collection/data logic (`books.py`, `books.js`, `Services/BookCollection.cs`)
+  - JSON file persistence (`data.json`)
+  - tests colocated in each sample project (`tests/`, `Tests/`)
+
+### 3) Demo automation layer
+
+- `.github/scripts/demos.json` is the source of truth for recorded chapter demos (prompt text, chapter mapping, timing overrides).
+- `npm run release` uses:
+  - `.github/scripts/create-tapes.js` to generate `.tape` files
+  - `.github/scripts/generate-demos.js` to render GIFs via VHS
+  - `.github/scripts/verify-gifs.js` to validate generated GIF completion
+
+### 4) Copilot customization layer
+
+- Repository-level assistants are in `.github/agents/` and `.github/skills/`.
+- Matching templates/examples are in `samples/agents/` and `samples/skills/` for teaching purposes.
+
 ## Writing Conventions
 
 - **Audience**: Beginners with no AI/ML experience. Explain every technical term on first use.
@@ -50,6 +130,23 @@ Do not deviate from this structure when editing or adding chapter content.
 - Images go in the repo-root `images/` directory.
 - Use relative links for cross-chapter references (e.g., `../03-development-workflows/README.md`).
 - Emoji usage is encouraged for section headers (matching existing style).
+
+## Key Repository Conventions
+
+- Treat this as **courseware first**: edits should preserve teaching intent, not just code correctness.
+- Prefer `samples/book-app-project/` (Python) in chapter examples unless a chapter explicitly compares languages.
+- For `samples/book-app-buggy/` and `samples/buggy-code/`, default to **debugging explanations** (root cause + proposed patch). Only edit those files when the user explicitly asks to apply the fix in-file.
+- Keep chapter structure consistent: Real-World Analogy → Core Concepts → Hands-On Examples → Assignment → What’s Next.
+- Use kebab-case consistently for session names, filenames, and identifiers shown to learners.
+- Use `--flag=value` style when a command flag requires a value.
+- If a change affects cross-file course consistency, update linked surfaces from the maintenance matrix below.
+- Keep glossary additions in `GLOSSARY.md` alphabetized when introducing new terms.
+
+## Session-History Guardrails
+
+- For direct implementation requests (e.g., “add/fix/refactor X”), **implement immediately**. Do not block on “say start” or planning-only loops unless the user explicitly asks for planning first.
+- When behavior changes in `samples/book-app-project/`, update or add pytest coverage in `samples/book-app-project/tests/test_*.py` within the same task.
+- If the user repeats the same prompt verbatim, treat it as a recovery signal: avoid re-sending near-identical output, acknowledge the miss briefly, and respond with a different, more actionable format.
 
 ## Maintenance Matrix
 

--- a/samples/book-app-buggy/book_app_buggy.py
+++ b/samples/book-app-buggy/book_app_buggy.py
@@ -6,7 +6,7 @@ from books_buggy import BookCollection
 collection = BookCollection()
 
 
-def show_books(books):
+def show_books(books) -> None:
     """Display books in a user-friendly format."""
     if not books:
         print("No books found.")
@@ -22,17 +22,22 @@ def show_books(books):
     print()
 
 
-def handle_list():
+def handle_list() -> None:
     books = collection.list_books()
     show_books(books)
 
 
-def handle_add():
-    print("\nAdd a New Book\n")
-
+def _prompt_add_inputs():
+    """Collect add-book input fields from the user."""
     title = input("Title: ").strip()
     author = input("Author: ").strip()
     year_str = input("Year: ").strip()
+    return title, author, year_str
+
+
+def handle_add() -> None:
+    print("\nAdd a New Book\n")
+    title, author, year_str = _prompt_add_inputs()
 
     # BUG 8: No validation on empty title or author
     try:
@@ -43,17 +48,17 @@ def handle_add():
         print(f"\nError: {e}\n")
 
 
-def handle_remove():
+def handle_remove() -> None:
     print("\nRemove a Book\n")
 
     title = input("Enter the title of the book to remove: ").strip()
-    result = collection.remove_book(title)
+    _removed = collection.remove_book(title)
 
     # BUG 9: Always says "removed" even when book wasn't found
     print("\nBook removed.\n")
 
 
-def handle_find():
+def handle_find() -> None:
     print("\nFind Books by Author\n")
 
     author = input("Author name: ").strip()
@@ -62,7 +67,7 @@ def handle_find():
     show_books(books)
 
 
-def show_help():
+def show_help() -> None:
     print("""
 Book Collection Helper
 
@@ -75,26 +80,27 @@ Commands:
 """)
 
 
-def main():
+def main() -> None:
+    command_handlers = {
+        "list": handle_list,
+        "add": handle_add,
+        "remove": handle_remove,
+        "find": handle_find,
+        "help": show_help,
+    }
+
     if len(sys.argv) < 2:
         show_help()
         return
 
     command = sys.argv[1].lower()
+    handler = command_handlers.get(command)
+    if handler:
+        handler()
+        return
 
-    if command == "list":
-        handle_list()
-    elif command == "add":
-        handle_add()
-    elif command == "remove":
-        handle_remove()
-    elif command == "find":
-        handle_find()
-    elif command == "help":
-        show_help()
-    else:
-        print("Unknown command.\n")
-        show_help()
+    print("Unknown command.\n")
+    show_help()
 
 
 if __name__ == "__main__":

--- a/samples/book-app-buggy/books_buggy.py
+++ b/samples/book-app-buggy/books_buggy.py
@@ -58,8 +58,7 @@ class BookCollection:
         # BUG 5: Marks ALL books as read instead of just the matching one
         book = self.find_book_by_title(title)
         if book:
-            for b in self.books:
-                b.read = True
+            book.read = True
             self.save_books()
             return True
         return False

--- a/samples/book-app-buggy/tests/test_handle_add.py
+++ b/samples/book-app-buggy/tests/test_handle_add.py
@@ -1,0 +1,71 @@
+import importlib
+import sys
+
+import pytest
+
+
+class FakeCollection:
+    def __init__(self):
+        self.calls = []
+
+    def add_book(self, title, author, year):
+        self.calls.append((title, author, year))
+
+
+@pytest.fixture
+def app_module(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("book_app_buggy", None)
+    module = importlib.import_module("book_app_buggy")
+    return module
+
+
+class TestHandleAdd:
+    def test_adds_book_with_valid_input(self, app_module, monkeypatch, capsys):
+        fake_collection = FakeCollection()
+        monkeypatch.setattr(app_module, "collection", fake_collection)
+
+        inputs = iter(["Dune", "Frank Herbert", "1965"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        app_module.handle_add()
+
+        assert fake_collection.calls == [("Dune", "Frank Herbert", 1965)]
+        assert "Book added successfully." in capsys.readouterr().out
+
+    def test_defaults_year_to_zero_when_empty(self, app_module, monkeypatch):
+        fake_collection = FakeCollection()
+        monkeypatch.setattr(app_module, "collection", fake_collection)
+
+        inputs = iter(["Neuromancer", "William Gibson", ""])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        app_module.handle_add()
+
+        assert fake_collection.calls == [("Neuromancer", "William Gibson", 0)]
+
+    @pytest.mark.parametrize("year_input", ["abc", "19.5", "two thousand"])
+    def test_shows_error_for_non_integer_year(
+        self, app_module, monkeypatch, capsys, year_input
+    ):
+        fake_collection = FakeCollection()
+        monkeypatch.setattr(app_module, "collection", fake_collection)
+
+        inputs = iter(["Dune", "Frank Herbert", year_input])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        app_module.handle_add()
+
+        assert fake_collection.calls == []
+        assert "Error:" in capsys.readouterr().out
+
+    def test_passes_empty_title_and_author_through(self, app_module, monkeypatch):
+        fake_collection = FakeCollection()
+        monkeypatch.setattr(app_module, "collection", fake_collection)
+
+        inputs = iter(["", "", "2000"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        app_module.handle_add()
+
+        assert fake_collection.calls == [("", "", 2000)]

--- a/samples/book-app-buggy/tests/test_mark_as_read.py
+++ b/samples/book-app-buggy/tests/test_mark_as_read.py
@@ -1,0 +1,41 @@
+import json
+
+import pytest
+
+from books_buggy import Book, BookCollection
+
+
+@pytest.fixture
+def collection(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    c = BookCollection()
+    c.books = [
+        Book(title="Dune", author="Frank Herbert", year=1965, read=False),
+        Book(title="Neuromancer", author="William Gibson", year=1984, read=False),
+    ]
+    c.save_books()
+    return c
+
+
+class TestMarkAsRead:
+    def test_marks_only_matching_book_as_read(self, collection):
+        result = collection.mark_as_read("Dune")
+
+        assert result is True
+        assert collection.books[0].read is True
+        assert collection.books[1].read is False
+
+    def test_returns_false_when_book_not_found(self, collection):
+        result = collection.mark_as_read("Foundation")
+
+        assert result is False
+        assert [b.read for b in collection.books] == [False, False]
+
+    def test_persists_read_state_for_only_target_book(self, collection, tmp_path):
+        collection.mark_as_read("Neuromancer")
+
+        data = json.loads((tmp_path / "data.json").read_text())
+        assert data[0]["title"] == "Dune"
+        assert data[0]["read"] is False
+        assert data[1]["title"] == "Neuromancer"
+        assert data[1]["read"] is True

--- a/samples/book-app-project/tests/test_books.py
+++ b/samples/book-app-project/tests/test_books.py
@@ -2,52 +2,614 @@ import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import json
+import threading
 import pytest
+from unittest.mock import patch, mock_open
 import books
-from books import BookCollection
+from books import Book, BookCollection
 
 
 @pytest.fixture(autouse=True)
 def use_temp_data_file(tmp_path, monkeypatch):
-    """Use a temporary data file for each test."""
+    """Redirect DATA_FILE to a temp path for every test."""
     temp_file = tmp_path / "data.json"
     temp_file.write_text("[]")
     monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
 
 
-def test_add_book():
-    collection = BookCollection()
-    initial_count = len(collection.books)
-    collection.add_book("1984", "George Orwell", 1949)
-    assert len(collection.books) == initial_count + 1
-    book = collection.find_book_by_title("1984")
-    assert book is not None
-    assert book.author == "George Orwell"
-    assert book.year == 1949
-    assert book.read is False
+@pytest.fixture
+def collection():
+    return BookCollection()
 
-def test_mark_book_as_read():
-    collection = BookCollection()
-    collection.add_book("Dune", "Frank Herbert", 1965)
-    result = collection.mark_as_read("Dune")
-    assert result is True
-    book = collection.find_book_by_title("Dune")
-    assert book.read is True
 
-def test_mark_book_as_read_invalid():
-    collection = BookCollection()
-    result = collection.mark_as_read("Nonexistent Book")
-    assert result is False
+@pytest.fixture
+def populated_collection():
+    col = BookCollection()
+    col.add_book("1984", "George Orwell", 1949)
+    col.add_book("Animal Farm", "George Orwell", 1945)
+    col.add_book("Dune", "Frank Herbert", 1965)
+    return col
 
-def test_remove_book():
-    collection = BookCollection()
-    collection.add_book("The Hobbit", "J.R.R. Tolkien", 1937)
-    result = collection.remove_book("The Hobbit")
-    assert result is True
-    book = collection.find_book_by_title("The Hobbit")
-    assert book is None
 
-def test_remove_book_invalid():
-    collection = BookCollection()
-    result = collection.remove_book("Nonexistent Book")
-    assert result is False
+# ---------------------------------------------------------------------------
+# Book dataclass
+# ---------------------------------------------------------------------------
+
+class TestBook:
+    def test_defaults_read_false(self):
+        book = Book(title="Test", author="Author", year=2000)
+        assert book.read is False
+
+    def test_explicit_read_true(self):
+        book = Book(title="Test", author="Author", year=2000, read=True)
+        assert book.read is True
+
+
+# ---------------------------------------------------------------------------
+# load_books
+# ---------------------------------------------------------------------------
+
+class TestLoadBooks:
+    def test_loads_empty_file(self, collection):
+        assert collection.books == []
+
+    def test_loads_existing_books(self, tmp_path, monkeypatch):
+        data = [{"title": "1984", "author": "George Orwell", "year": 1949, "read": False}]
+        temp_file = tmp_path / "data.json"
+        temp_file.write_text(json.dumps(data))
+        monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
+
+        col = BookCollection()
+        assert len(col.books) == 1
+        assert col.books[0].title == "1984"
+
+    def test_missing_file_starts_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(books, "DATA_FILE", str(tmp_path / "nonexistent.json"))
+        col = BookCollection()
+        assert col.books == []
+
+    def test_corrupted_json_starts_empty(self, tmp_path, monkeypatch, capsys):
+        temp_file = tmp_path / "data.json"
+        temp_file.write_text("this is not json {{{")
+        monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
+
+        col = BookCollection()
+        assert col.books == []
+        captured = capsys.readouterr()
+        assert "corrupted" in captured.out.lower() or "warning" in captured.out.lower()
+
+
+# ---------------------------------------------------------------------------
+# save_books
+# ---------------------------------------------------------------------------
+
+class TestSaveBooks:
+    def test_save_persists_to_disk(self, tmp_path, monkeypatch):
+        temp_file = tmp_path / "data.json"
+        temp_file.write_text("[]")
+        monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
+
+        col = BookCollection()
+        col.add_book("Dune", "Frank Herbert", 1965)
+
+        saved = json.loads(temp_file.read_text())
+        assert len(saved) == 1
+        assert saved[0]["title"] == "Dune"
+
+    def test_save_and_reload_roundtrip(self, tmp_path, monkeypatch):
+        temp_file = tmp_path / "data.json"
+        temp_file.write_text("[]")
+        monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
+
+        col1 = BookCollection()
+        col1.add_book("Dune", "Frank Herbert", 1965)
+        col1.mark_as_read("Dune")
+
+        col2 = BookCollection()
+        assert len(col2.books) == 1
+        assert col2.books[0].read is True
+
+
+# ---------------------------------------------------------------------------
+# add_book
+# ---------------------------------------------------------------------------
+
+class TestAddBook:
+    def test_add_book(self, collection):
+        collection.add_book("1984", "George Orwell", 1949)
+        assert len(collection.books) == 1
+
+    def test_add_book_returns_book(self, collection):
+        result = collection.add_book("1984", "George Orwell", 1949)
+        assert isinstance(result, Book)
+        assert result.title == "1984"
+        assert result.author == "George Orwell"
+        assert result.year == 1949
+
+    def test_add_book_read_defaults_false(self, collection):
+        book = collection.add_book("1984", "George Orwell", 1949)
+        assert book.read is False
+
+    def test_add_multiple_books(self, collection):
+        collection.add_book("1984", "George Orwell", 1949)
+        collection.add_book("Dune", "Frank Herbert", 1965)
+        assert len(collection.books) == 2
+
+    def test_add_duplicate_title(self, collection):
+        collection.add_book("1984", "George Orwell", 1949)
+        collection.add_book("1984", "George Orwell", 1949)
+        assert len(collection.books) == 2
+
+    @pytest.mark.parametrize("title,author,year", [
+        ("1984", "George Orwell", 1949),
+        ("Dune", "Frank Herbert", 1965),
+        ("The Hobbit", "J.R.R. Tolkien", 1937),
+    ])
+    def test_add_various_books(self, collection, title, author, year):
+        book = collection.add_book(title, author, year)
+        assert book.title == title
+        assert book.author == author
+        assert book.year == year
+
+
+# ---------------------------------------------------------------------------
+# list_books
+# ---------------------------------------------------------------------------
+
+class TestListBooks:
+    def test_list_empty(self, collection):
+        assert collection.list_books() == []
+
+    def test_list_returns_all(self, populated_collection):
+        result = populated_collection.list_books()
+        assert len(result) == 3
+
+    def test_list_returns_book_objects(self, populated_collection):
+        result = populated_collection.list_books()
+        assert all(isinstance(b, Book) for b in result)
+
+    def test_list_is_same_reference(self, populated_collection):
+        assert populated_collection.list_books() is populated_collection.books
+
+
+# ---------------------------------------------------------------------------
+# find_book_by_title
+# ---------------------------------------------------------------------------
+
+class TestFindBookByTitle:
+    def test_find_existing_book(self, populated_collection):
+        book = populated_collection.find_book_by_title("1984")
+        assert book is not None
+        assert book.title == "1984"
+
+    def test_find_nonexistent_returns_none(self, populated_collection):
+        assert populated_collection.find_book_by_title("Unknown Book") is None
+
+    def test_find_case_insensitive(self, populated_collection):
+        assert populated_collection.find_book_by_title("dune") is not None
+        assert populated_collection.find_book_by_title("DUNE") is not None
+        assert populated_collection.find_book_by_title("DuNe") is not None
+
+    def test_find_empty_collection(self, collection):
+        assert collection.find_book_by_title("1984") is None
+
+    @pytest.mark.parametrize("title", ["1984", "Dune", "Animal Farm"])
+    def test_find_each_added_book(self, populated_collection, title):
+        assert populated_collection.find_book_by_title(title) is not None
+
+
+# ---------------------------------------------------------------------------
+# mark_as_read
+# ---------------------------------------------------------------------------
+
+class TestMarkAsRead:
+    def test_mark_existing_book(self, populated_collection):
+        result = populated_collection.mark_as_read("Dune")
+        assert result is True
+        assert populated_collection.find_book_by_title("Dune").read is True
+
+    def test_mark_nonexistent_returns_false(self, collection):
+        assert collection.mark_as_read("Nonexistent Book") is False
+
+    def test_mark_case_insensitive(self, populated_collection):
+        result = populated_collection.mark_as_read("dune")
+        assert result is True
+
+    def test_mark_already_read(self, populated_collection):
+        populated_collection.mark_as_read("Dune")
+        result = populated_collection.mark_as_read("Dune")
+        assert result is True
+        assert populated_collection.find_book_by_title("Dune").read is True
+
+    def test_mark_does_not_affect_other_books(self, populated_collection):
+        populated_collection.mark_as_read("Dune")
+        assert populated_collection.find_book_by_title("1984").read is False
+
+
+# ---------------------------------------------------------------------------
+# remove_book
+# ---------------------------------------------------------------------------
+
+class TestRemoveBook:
+    def test_remove_existing_book(self, populated_collection):
+        result = populated_collection.remove_book("Dune")
+        assert result is True
+        assert populated_collection.find_book_by_title("Dune") is None
+
+    def test_remove_nonexistent_returns_false(self, collection):
+        assert collection.remove_book("Ghost Book") is False
+
+    def test_remove_decrements_count(self, populated_collection):
+        before = len(populated_collection.books)
+        populated_collection.remove_book("Dune")
+        assert len(populated_collection.books) == before - 1
+
+    def test_remove_case_insensitive(self, populated_collection):
+        result = populated_collection.remove_book("DUNE")
+        assert result is True
+
+    def test_remove_does_not_affect_other_books(self, populated_collection):
+        populated_collection.remove_book("Dune")
+        assert populated_collection.find_book_by_title("1984") is not None
+
+    def test_remove_from_empty_collection(self, collection):
+        assert collection.remove_book("1984") is False
+
+
+# ---------------------------------------------------------------------------
+# find_by_author
+# ---------------------------------------------------------------------------
+
+class TestFindByAuthor:
+    def test_find_author_with_multiple_books(self, populated_collection):
+        result = populated_collection.find_by_author("George Orwell")
+        assert len(result) == 2
+        assert all(b.author == "George Orwell" for b in result)
+
+    def test_find_author_with_one_book(self, populated_collection):
+        result = populated_collection.find_by_author("Frank Herbert")
+        assert len(result) == 1
+        assert result[0].title == "Dune"
+
+    def test_find_unknown_author_returns_empty(self, populated_collection):
+        assert populated_collection.find_by_author("Unknown Author") == []
+
+    def test_find_author_case_insensitive(self, populated_collection):
+        assert len(populated_collection.find_by_author("george orwell")) == 2
+        assert len(populated_collection.find_by_author("GEORGE ORWELL")) == 2
+
+    def test_find_author_empty_collection(self, collection):
+        assert collection.find_by_author("George Orwell") == []
+
+    def test_find_author_returns_book_objects(self, populated_collection):
+        result = populated_collection.find_by_author("George Orwell")
+        assert all(isinstance(b, Book) for b in result)
+
+    @pytest.mark.parametrize(
+        "author,title",
+        [
+            ("Jean-Paul Sartre", "Nausea"),
+            ("Joanne Kathleen Rowling", "Harry Potter and the Philosopher's Stone"),
+            ("Gabriel García Márquez", "One Hundred Years of Solitude"),
+        ],
+    )
+    def test_find_author_with_special_name_patterns(self, collection, author, title):
+        collection.add_book(title, author, 1967)
+        result = collection.find_by_author(author)
+        assert len(result) == 1
+        assert result[0].title == title
+        assert result[0].author == author
+
+    @pytest.mark.parametrize(
+        "author,title,query",
+        [
+            ("Jean-Paul Sartre", "Nausea", "jean-paul sartre"),
+            ("Joanne Kathleen Rowling", "Harry Potter and the Philosopher's Stone", "JOANNE KATHLEEN ROWLING"),
+            ("Gabriel García Márquez", "One Hundred Years of Solitude", "gabriel garcía márquez"),
+        ],
+    )
+    def test_find_author_special_name_patterns_case_insensitive(self, collection, author, title, query):
+        collection.add_book(title, author, 1967)
+        result = collection.find_by_author(query)
+        assert len(result) == 1
+        assert result[0].author == author
+
+    def test_find_author_empty_string_matches_books_with_empty_author(self, collection):
+        collection.add_book("Untitled Notes", "", 2020)
+        collection.add_book("Dune", "Frank Herbert", 1965)
+        result = collection.find_by_author("")
+        assert len(result) == 1
+        assert result[0].title == "Untitled Notes"
+        assert result[0].author == ""
+
+    def test_find_author_empty_string_returns_empty_when_no_empty_author(self, populated_collection):
+        assert populated_collection.find_by_author("") == []
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+class TestIntegration:
+    def test_add_find_read_remove_workflow(self, collection):
+        collection.add_book("Neuromancer", "William Gibson", 1984)
+        book = collection.find_book_by_title("Neuromancer")
+        assert book is not None and book.read is False
+
+        collection.mark_as_read("Neuromancer")
+        assert collection.find_book_by_title("Neuromancer").read is True
+
+        collection.remove_book("Neuromancer")
+        assert collection.find_book_by_title("Neuromancer") is None
+        assert collection.list_books() == []
+
+    def test_find_by_author_after_remove(self, populated_collection):
+        populated_collection.remove_book("Animal Farm")
+        result = populated_collection.find_by_author("George Orwell")
+        assert len(result) == 1
+        assert result[0].title == "1984"
+
+    def test_persistence_across_instances(self, tmp_path, monkeypatch):
+        temp_file = tmp_path / "data.json"
+        temp_file.write_text("[]")
+        monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
+
+        col1 = BookCollection()
+        col1.add_book("Foundation", "Isaac Asimov", 1951)
+        col1.mark_as_read("Foundation")
+
+        col2 = BookCollection()
+        book = col2.find_book_by_title("Foundation")
+        assert book is not None
+        assert book.read is True
+
+
+# ---------------------------------------------------------------------------
+# Duplicate books
+# ---------------------------------------------------------------------------
+
+class TestDuplicateBooks:
+    def test_add_exact_duplicate_allows_both(self, collection):
+        """BookCollection does not enforce uniqueness — both entries are stored."""
+        collection.add_book("1984", "George Orwell", 1949)
+        collection.add_book("1984", "George Orwell", 1949)
+        assert len(collection.books) == 2
+
+    def test_add_same_title_different_author(self, collection):
+        collection.add_book("1984", "George Orwell", 1949)
+        collection.add_book("1984", "Another Author", 2020)
+        assert len(collection.books) == 2
+
+    def test_add_same_title_different_year(self, collection):
+        collection.add_book("1984", "George Orwell", 1949)
+        collection.add_book("1984", "George Orwell", 2003)
+        assert len(collection.books) == 2
+
+    def test_find_by_title_returns_first_duplicate(self, collection):
+        """find_book_by_title returns the first match when duplicates exist."""
+        collection.add_book("1984", "George Orwell", 1949)
+        collection.add_book("1984", "George Orwell", 2003)
+        found = collection.find_book_by_title("1984")
+        assert found.year == 1949
+
+    def test_remove_duplicate_removes_only_first(self, collection):
+        """remove_book removes the first match, leaving the second duplicate."""
+        collection.add_book("1984", "George Orwell", 1949)
+        collection.add_book("1984", "George Orwell", 2003)
+        collection.remove_book("1984")
+        assert len(collection.books) == 1
+        assert collection.books[0].year == 2003
+
+    def test_mark_as_read_marks_first_duplicate(self, collection):
+        """mark_as_read only affects the first matching book."""
+        collection.add_book("1984", "George Orwell", 1949)
+        collection.add_book("1984", "George Orwell", 2003)
+        collection.mark_as_read("1984")
+        assert collection.books[0].read is True
+        assert collection.books[1].read is False
+
+    def test_duplicate_books_persist_to_disk(self, tmp_path, monkeypatch):
+        temp_file = tmp_path / "data.json"
+        temp_file.write_text("[]")
+        monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
+
+        col = BookCollection()
+        col.add_book("1984", "George Orwell", 1949)
+        col.add_book("1984", "George Orwell", 1949)
+
+        saved = json.loads(temp_file.read_text())
+        assert len(saved) == 2
+
+
+# ---------------------------------------------------------------------------
+# Partial title match behaviour
+# ---------------------------------------------------------------------------
+
+class TestPartialTitleMatch:
+    def test_find_by_partial_title_returns_none(self, populated_collection):
+        """find_book_by_title requires an exact (case-insensitive) match."""
+        assert populated_collection.find_book_by_title("19") is None
+        assert populated_collection.find_book_by_title("Du") is None
+
+    def test_remove_by_partial_title_returns_false(self, populated_collection):
+        """remove_book does not remove on a partial match."""
+        result = populated_collection.remove_book("19")
+        assert result is False
+        assert len(populated_collection.books) == 3
+
+    def test_mark_as_read_partial_title_returns_false(self, populated_collection):
+        result = populated_collection.mark_as_read("Du")
+        assert result is False
+
+    def test_substring_of_existing_title_not_found(self, populated_collection):
+        assert populated_collection.find_book_by_title("Animal") is None
+
+    def test_full_title_with_extra_space_not_found(self, populated_collection):
+        """Trailing space after strip is removed; extra interior space is not."""
+        assert populated_collection.find_book_by_title("1984 ") is None
+
+    def test_exact_match_still_works_after_partial_miss(self, populated_collection):
+        assert populated_collection.find_book_by_title("Dune") is not None
+
+
+# ---------------------------------------------------------------------------
+# Finding books when collection is empty
+# ---------------------------------------------------------------------------
+
+class TestEmptyCollectionLookups:
+    def test_find_book_by_title_empty(self, collection):
+        assert collection.find_book_by_title("Anything") is None
+
+    def test_find_by_author_empty(self, collection):
+        assert collection.find_by_author("George Orwell") == []
+
+    def test_list_books_empty(self, collection):
+        assert collection.list_books() == []
+
+    def test_mark_as_read_empty(self, collection):
+        assert collection.mark_as_read("Ghost") is False
+
+    def test_remove_book_empty(self, collection):
+        assert collection.remove_book("Ghost") is False
+
+    def test_empty_after_removing_all(self, collection):
+        collection.add_book("Dune", "Frank Herbert", 1965)
+        collection.remove_book("Dune")
+        assert collection.list_books() == []
+        assert collection.find_book_by_title("Dune") is None
+        assert collection.find_by_author("Frank Herbert") == []
+
+
+# ---------------------------------------------------------------------------
+# File permission errors during save
+# ---------------------------------------------------------------------------
+
+class TestFilePermissionErrors:
+    def test_add_book_propagates_permission_error(self, collection):
+        """save_books has no error handling — PermissionError bubbles up."""
+        with patch("builtins.open", side_effect=PermissionError("Permission denied")):
+            with pytest.raises(PermissionError):
+                collection.add_book("Dune", "Frank Herbert", 1965)
+
+    def test_mark_as_read_propagates_permission_error(self, collection):
+        collection.books.append(Book("Dune", "Frank Herbert", 1965))
+        with patch("builtins.open", side_effect=PermissionError("Permission denied")):
+            with pytest.raises(PermissionError):
+                collection.mark_as_read("Dune")
+
+    def test_remove_book_propagates_permission_error(self, collection):
+        collection.books.append(Book("Dune", "Frank Herbert", 1965))
+        with patch("builtins.open", side_effect=PermissionError("Permission denied")):
+            with pytest.raises(PermissionError):
+                collection.remove_book("Dune")
+
+    def test_in_memory_state_unchanged_after_permission_error(self, collection):
+        """If save fails, the in-memory list still reflects the attempted mutation."""
+        with pytest.raises(PermissionError):
+            with patch("builtins.open", side_effect=PermissionError):
+                collection.add_book("Dune", "Frank Herbert", 1965)
+        # book was appended before save was attempted
+        assert collection.find_book_by_title("Dune") is not None
+
+    def test_load_books_readonly_file_raises(self, tmp_path, monkeypatch):
+        """A truly unreadable file raises PermissionError on load."""
+        temp_file = tmp_path / "data.json"
+        temp_file.write_text("[]")
+        monkeypatch.setattr(books, "DATA_FILE", str(temp_file))
+
+        with patch("builtins.open", side_effect=PermissionError("no read")):
+            with pytest.raises(PermissionError):
+                BookCollection()
+
+
+# ---------------------------------------------------------------------------
+# Concurrent access
+# ---------------------------------------------------------------------------
+
+class TestConcurrentAccess:
+    def test_concurrent_adds_all_stored(self, collection):
+        """All books added from multiple threads should appear in the collection."""
+        errors = []
+
+        def add(n):
+            try:
+                collection.add_book(f"Book {n}", f"Author {n}", 2000 + n)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=add, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Threads raised: {errors}"
+        assert len(collection.books) == 10
+
+    def test_concurrent_reads_are_safe(self, populated_collection):
+        """Simultaneous reads should not raise and should return consistent results."""
+        results = []
+        errors = []
+
+        def read():
+            try:
+                results.append(len(populated_collection.list_books()))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=read) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert all(r == 3 for r in results)
+
+    def test_concurrent_mark_as_read(self, collection):
+        """Marking the same book as read from multiple threads should not corrupt state."""
+        collection.add_book("Dune", "Frank Herbert", 1965)
+        errors = []
+
+        def mark():
+            try:
+                collection.mark_as_read("Dune")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=mark) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert collection.find_book_by_title("Dune").read is True
+
+    def test_concurrent_add_and_read(self, collection):
+        """Mixed read/write threads should not raise exceptions."""
+        errors = []
+
+        def add(n):
+            try:
+                collection.add_book(f"Book {n}", "Author", 2000)
+            except Exception as e:
+                errors.append(e)
+
+        def read():
+            try:
+                collection.list_books()
+            except Exception as e:
+                errors.append(e)
+
+        threads = (
+            [threading.Thread(target=add, args=(i,)) for i in range(5)]
+            + [threading.Thread(target=read) for _ in range(5)]
+        )
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors

--- a/samples/book-app-project/tests/test_utils.py
+++ b/samples/book-app-project/tests/test_utils.py
@@ -1,0 +1,227 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import patch
+from utils import get_book_details
+
+
+def make_inputs(title, author, year):
+    """Helper to patch input() with three sequential responses."""
+    return patch("builtins.input", side_effect=[title, author, year])
+
+
+# ---------------------------------------------------------------------------
+# Valid input
+# ---------------------------------------------------------------------------
+
+class TestGetBookDetailsValidInput:
+    def test_returns_tuple_of_three(self):
+        with make_inputs("1984", "George Orwell", "1949"):
+            result = get_book_details()
+        assert len(result) == 3
+
+    def test_valid_book(self):
+        with make_inputs("1984", "George Orwell", "1949"):
+            title, author, year = get_book_details()
+        assert title == "1984"
+        assert author == "George Orwell"
+        assert year == 1949
+
+    def test_year_returned_as_int(self):
+        with make_inputs("Dune", "Frank Herbert", "1965"):
+            _, _, year = get_book_details()
+        assert isinstance(year, int)
+
+    def test_strips_whitespace_from_title(self):
+        with make_inputs("  1984  ", "George Orwell", "1949"):
+            title, _, _ = get_book_details()
+        assert title == "1984"
+
+    def test_strips_whitespace_from_author(self):
+        with make_inputs("Dune", "  Frank Herbert  ", "1965"):
+            _, author, _ = get_book_details()
+        assert author == "Frank Herbert"
+
+    def test_strips_whitespace_from_year(self):
+        with make_inputs("Dune", "Frank Herbert", "  1965  "):
+            _, _, year = get_book_details()
+        assert year == 1965
+
+    @pytest.mark.parametrize("title,author,year_str,expected_year", [
+        ("1984", "George Orwell", "1949", 1949),
+        ("Dune", "Frank Herbert", "1965", 1965),
+        ("The Hobbit", "J.R.R. Tolkien", "1937", 1937),
+        ("Foundation", "Isaac Asimov", "1951", 1951),
+    ])
+    def test_various_valid_books(self, title, author, year_str, expected_year):
+        with make_inputs(title, author, year_str):
+            t, a, y = get_book_details()
+        assert t == title
+        assert a == author
+        assert y == expected_year
+
+
+# ---------------------------------------------------------------------------
+# Empty strings
+# ---------------------------------------------------------------------------
+
+class TestGetBookDetailsEmptyStrings:
+    def test_empty_title_returns_empty_string(self):
+        with make_inputs("", "George Orwell", "1949"):
+            title, _, _ = get_book_details()
+        assert title == ""
+
+    def test_empty_author_returns_empty_string(self):
+        with make_inputs("1984", "", "1949"):
+            _, author, _ = get_book_details()
+        assert author == ""
+
+    def test_whitespace_only_title_stripped_to_empty(self):
+        with make_inputs("   ", "George Orwell", "1949"):
+            title, _, _ = get_book_details()
+        assert title == ""
+
+    def test_whitespace_only_author_stripped_to_empty(self):
+        with make_inputs("1984", "   ", "1949"):
+            _, author, _ = get_book_details()
+        assert author == ""
+
+    def test_empty_year_defaults_to_zero(self, capsys):
+        with make_inputs("1984", "George Orwell", ""):
+            _, _, year = get_book_details()
+        assert year == 0
+
+    def test_all_empty_inputs(self):
+        with make_inputs("", "", ""):
+            title, author, year = get_book_details()
+        assert title == ""
+        assert author == ""
+        assert year == 0
+
+
+# ---------------------------------------------------------------------------
+# Invalid year formats
+# ---------------------------------------------------------------------------
+
+class TestGetBookDetailsInvalidYear:
+    def test_non_numeric_year_defaults_to_zero(self, capsys):
+        with make_inputs("1984", "George Orwell", "nineteen-forty-nine"):
+            _, _, year = get_book_details()
+        assert year == 0
+
+    def test_invalid_year_prints_warning(self, capsys):
+        with make_inputs("1984", "George Orwell", "abc"):
+            get_book_details()
+        captured = capsys.readouterr()
+        assert "invalid year" in captured.out.lower()
+
+    def test_float_year_string_defaults_to_zero(self, capsys):
+        with make_inputs("1984", "George Orwell", "1949.5"):
+            _, _, year = get_book_details()
+        assert year == 0
+
+    def test_year_with_letters_defaults_to_zero(self, capsys):
+        with make_inputs("1984", "George Orwell", "1949abc"):
+            _, _, year = get_book_details()
+        assert year == 0
+
+    def test_negative_year_is_accepted_as_int(self):
+        with make_inputs("Ancient Text", "Unknown", "-500"):
+            _, _, year = get_book_details()
+        assert year == -500
+
+    def test_zero_year_is_accepted(self):
+        with make_inputs("Test", "Author", "0"):
+            _, _, year = get_book_details()
+        assert year == 0
+
+    def test_very_large_year_is_accepted(self):
+        with make_inputs("Future Book", "Author", "9999"):
+            _, _, year = get_book_details()
+        assert year == 9999
+
+    @pytest.mark.parametrize("bad_year", ["abc", "12.5", "20xx", "--", "year", "①②③"])
+    def test_various_invalid_years_default_to_zero(self, bad_year, capsys):
+        with make_inputs("Title", "Author", bad_year):
+            _, _, year = get_book_details()
+        assert year == 0
+
+
+# ---------------------------------------------------------------------------
+# Very long titles
+# ---------------------------------------------------------------------------
+
+class TestGetBookDetailsLongTitles:
+    def test_long_title_preserved(self):
+        long_title = "A" * 500
+        with make_inputs(long_title, "Author", "2000"):
+            title, _, _ = get_book_details()
+        assert title == long_title
+
+    def test_long_title_still_stripped(self):
+        long_title = "  " + "B" * 300 + "  "
+        with make_inputs(long_title, "Author", "2000"):
+            title, _, _ = get_book_details()
+        assert title == "B" * 300
+
+    def test_long_author_name_preserved(self):
+        long_author = "Gabriel " * 50
+        with make_inputs("Title", long_author, "2000"):
+            _, author, _ = get_book_details()
+        assert author == long_author.strip()
+
+    def test_title_with_spaces_preserved(self):
+        spaced = "The " * 100
+        with make_inputs(spaced, "Author", "2000"):
+            title, _, _ = get_book_details()
+        assert title == spaced.strip()
+
+
+# ---------------------------------------------------------------------------
+# Special characters in author names
+# ---------------------------------------------------------------------------
+
+class TestGetBookDetailsSpecialCharacters:
+    @pytest.mark.parametrize("author", [
+        "J.R.R. Tolkien",
+        "Ursula K. Le Guin",
+        "Gabriel García Márquez",
+        "Haruki Murakami (村上春樹)",
+        "Nnedi Okofor-Obi",
+        "Jean-Paul Sartre",
+        "bell hooks",
+        "O'Henry",
+        "Author & Co-Author",
+        "Name <email@example.com>",
+        "Author's Name",
+        "Ångström, Anders",
+    ])
+    def test_special_character_authors(self, author):
+        with make_inputs("Some Book", author, "2000"):
+            _, result_author, _ = get_book_details()
+        assert result_author == author
+
+    def test_title_with_punctuation(self):
+        title = "It's a Wonderful Life: A Story (2nd Ed.)"
+        with make_inputs(title, "Author", "1990"):
+            result_title, _, _ = get_book_details()
+        assert result_title == title
+
+    def test_title_with_unicode(self):
+        title = "café au lait & bœuf — a novel"
+        with make_inputs(title, "Author", "2010"):
+            result_title, _, _ = get_book_details()
+        assert result_title == title
+
+    def test_title_with_newline_stripped(self):
+        with make_inputs("Title\n", "Author", "2000"):
+            title, _, _ = get_book_details()
+        assert title == "Title"
+
+    def test_author_with_emoji(self):
+        author = "Author 📚"
+        with make_inputs("Book", author, "2021"):
+            _, result_author, _ = get_book_details()
+        assert result_author == author


### PR DESCRIPTION
## Summary
- Add comprehensive pytest coverage for the Python book app utilities and collection logic.
- Add regression tests for the intentionally buggy sample app to cover add and mark-as-read flows.
- Update the repository Copilot guidance file to document the course conventions.

## Validation
- `cd samples/book-app-project && python3 -m pytest tests -q`
- `cd samples/book-app-buggy && python3 -m pytest tests -q`
