### PR TITLE
[bot] Add Copilot CLI v1.0.81 features documentation (Aug 2026)

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -417,6 +417,8 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/settings` | Open an interactive dialog to browse and edit all user settings in one place |
 | `/skills` | Manage skills for enhanced capabilities |
 
+> 💡 **Set your default startup mode**: In `/settings`, look for `defaultMode` to choose which mode Copilot opens in by default (interactive, plan, or autopilot). You can also set `defaultPermissionMode` to control how Copilot handles permission prompts across all new sessions — handy if you find yourself changing these settings repeatedly.
+
 > 💡 Agents are covered in [Chapter 04](../04-agents-custom-instructions/README.md), skills are covered in [Chapter 05](../05-skills/README.md), and MCP servers are covered in [Chapter 06](../06-mcp-servers/README.md).
 
 ### Models and Subagents
@@ -481,6 +483,8 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/theme` | View or set terminal theme |
 | `/voice` | Dictate your prompt using local speech-to-text — speak naturally instead of typing |
 
+> 💡 **Ctrl+Space for voice**: You can also press **Ctrl+Space** as a keyboard shortcut to toggle voice dictation on and off, without having to type `/voice`.
+
 ### Help and Feedback
 
 | Command | What It Does |
@@ -489,6 +493,8 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/changelog` | Display changelog for CLI versions |
 | `/feedback` | Submit feedback to GitHub |
 | `/help` | Show all available commands |
+
+> 💡 **`copilot app` from the terminal**: You can also run `copilot app` directly from your terminal (before starting a session) to open the GitHub Copilot app in the current directory — no need to start an interactive session first.
 
 ### Quick Shell Commands
 

--- a/02-context-conversations/README.md
+++ b/02-context-conversations/README.md
@@ -465,6 +465,8 @@ Issue #1 (duplicate functions) was fixed on Monday.
 
 No re-explaining. No re-reading files. Just continue working.
 
+> 💡 **Session restore after a crash or restart**: If the CLI crashes or your machine restarts while a session is open, Copilot will offer to restore those sessions the next time you start it. You'll see a prompt asking if you'd like to pick up where you left off — no manual `--resume` needed.
+
 ---
 
 **🎉 You now know the essentials!** The `@` syntax, session management (`--name`/`--continue`/`--resume`/`/rename`), and context commands (`/context`/`/clear`) are enough to be highly productive. Everything below is optional. Return to it when you're ready.

--- a/05-skills/README.md
+++ b/05-skills/README.md
@@ -304,6 +304,9 @@ Copilot automatically scans these locations for skills:
 |----------|-------|
 | `.github/skills/` | Project-specific (shared with team via git) |
 | `~/.copilot/skills/` | User-specific (your personal skills) |
+| Directories added with `--add-dir` | Any extra directories you pass at startup (e.g., `copilot --add-dir ~/my-tools`) |
+
+> 💡 **Skills from extra directories**: If you start Copilot with `--add-dir`, any `.github/skills/` folders inside those directories are automatically scanned too. This means you can maintain a shared folder of skills and point multiple projects at it, without copying files around. The same applies to custom agents.
 
 ### Skill Structure
 


### PR DESCRIPTION
## What's New in Copilot CLI v1.0.81 (past 7 days)

The following beginner-relevant features were released in **v1.0.81-6 through v1.0.81-8** (August 19–23, 2026) and are not yet documented in the course:

| Feature | Release | Chapter |
|---------|---------|---------|
| `copilot app` CLI command — opens the GitHub Copilot app from the terminal | v1.0.81-7 | Ch 01 |
| `Ctrl+Space` keyboard shortcut to toggle voice dictation | v1.0.81-7 | Ch 01 |
| `defaultMode` and `defaultPermissionMode` user settings | v1.0.81-6 | Ch 01 |
| Session restore on startup after a crash or machine restart | v1.0.81-7 | Ch 02 |
| Skills and custom agents auto-discovered from `--add-dir` directories | v1.0.81-8 | Ch 05 |

## Sections Updated

### Chapter 01 — First Steps (`01-setup-and-first-steps/README.md`)
- **Display commands table**: Added a tip that `Ctrl+Space` toggles voice dictation (alongside the existing `/voice` entry).
- **Help and Feedback commands table**: Added a tip explaining `copilot app` as a terminal-level command (companion to the `/app` slash command already documented).
- **Agent Environment commands table**: Added a tip about the new `defaultMode` and `defaultPermissionMode` settings, accessible via `/settings`, so beginners know they can configure their default startup mode once instead of switching each session.

### Chapter 02 — Context & Conversations (`02-context-conversations/README.md`)
- **Pick Up Where You Left Off section**: Added a tip explaining that Copilot now automatically offers to restore sessions that were open when the CLI went away (crash or machine restart) — no manual `--resume` required.

### Chapter 05 — Skills (`05-skills/README.md`)
- **How Copilot Finds Skills table**: Added a new row for directories added with `--add-dir`, plus a tip explaining that skills and custom agents in those directories are automatically discovered. Useful for teams that maintain a shared skills folder.

## Source Announcements

- [v1.0.81-6 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.81-6)
- [v1.0.81-7 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.81-7)
- [v1.0.81-8 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.81-8)

## Notes

Advanced/enterprise features (ACP client subagent IDs, managed enterprise policy changes, forceRemoteSettingsRefresh, xhigh reasoning effort for Grok 4.6) were intentionally excluded as they are not beginner-relevant.




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/32723548353/agentic_workflow) · ● 1.5M · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 32723548353, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/32723548353 -->

<!-- gh-aw-workflow-id: course-updater -->