### PR TITLE
[bot] Update slash commands: replace removed /plugins with /plugin, /instructions, /subagents (v1.0.81)

### DIFF
--- a/01-setup-and-first-steps/README.md
+++ b/01-setup-and-first-steps/README.md
@@ -412,10 +412,12 @@ That's it for getting started! As you become comfortable, you can explore additi
 | `/agent` | Browse and select from available agents |
 | `/env` | Show loaded environment details — what instructions, MCP servers, skills, agents, and plugins are active |
 | `/init` | Initialize Copilot instructions for your repository |
-| `/mcp` | Manage MCP server configuration |
-| `/plugins` | Enable or disable plugins, instructions, agents, LSP servers, and hooks without restarting the session |
+| `/instructions` | View and manage all loaded instruction files for the current session |
+| `/mcp` | Open the plugins dashboard (focused on MCP servers); use `/mcp config` for the dedicated MCP setup wizard |
+| `/plugin` | Open the plugins dashboard to browse, install, enable, and update plugins |
 | `/settings` | Open an interactive dialog to browse and edit all user settings in one place |
-| `/skills` | Manage skills for enhanced capabilities |
+| `/skills` | Open the plugins dashboard (focused on skills) to discover and manage skills |
+| `/subagents` | View and manage subagents running in the current session |
 
 > 💡 Agents are covered in [Chapter 04](../04-agents-custom-instructions/README.md), skills are covered in [Chapter 05](../05-skills/README.md), and MCP servers are covered in [Chapter 06](../06-mcp-servers/README.md).
 


### PR DESCRIPTION
## What changed in Copilot CLI

**v1.0.81 (2026-08-27)** removed the `/plugins` command. Its functionality was split across three dedicated commands:
- `/plugin` — manage the plugins dashboard (browse, install, enable, update)
- `/instructions` — view and manage loaded instruction files
- `/subagents` — view and manage subagents in the session

Additionally, `/mcp` (bare) and `/skills` now open the unified plugins dashboard; `/mcp config` is still the dedicated MCP setup wizard.

Source: https://github.com/github/copilot-cli/releases/tag/v1.0.81

## What was updated

**Chapter 01: First Steps** (`01-setup-and-first-steps/README.md`) — Agent Environment slash commands table:
- Removed the now-defunct `/plugins` row
- Added `/plugin` with accurate description of the plugins dashboard
- Added `/instructions` (new command for viewing loaded instruction files)
- Added `/subagents` (new command for managing session subagents)
- Updated `/mcp` description to reflect dashboard behavior and point to `/mcp config` for the MCP wizard
- Updated `/skills` description to reflect dashboard behavior

## Why this matters for beginners

The `/plugins` command no longer exists — learners who try to run it will get an error. The table now accurately reflects the commands available in v1.0.81+, so beginners can use them with confidence.




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/33387991168/agentic_workflow) · ● 803.2K · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 33387991168, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/33387991168 -->

<!-- gh-aw-workflow-id: course-updater -->