### PR TITLE
[bot] Update agent model config and MCP dashboard docs for v1.0.83

### DIFF
--- a/04-agents-custom-instructions/README.md
+++ b/04-agents-custom-instructions/README.md
@@ -582,6 +582,8 @@ You are a Python specialist focused on code quality and best practices.
 | `name` | No | Display name (defaults to filename) |
 | `description` | **Yes** | What the agent does - helps Copilot understand when to suggest it |
 | `tools` | No | List of allowed tools (omit = all tools available). See tool aliases below. |
+| `model` | No | AI model(s) to use. Can be a single model ID or a list tried in order. |
+| `model-policy` | No | Set to `required` to lock model changes to your list. |
 | `target` | No | Limit to `vscode` or `github-copilot` only |
 
 ### Tool Aliases
@@ -593,9 +595,37 @@ Use these names in the `tools` list:
 - `execute` - Run shell commands (also: `shell`, `Bash`)
 - `agent` - Invoke other custom agents
 
+### Specifying Models in an Agent
+
+You can pin an agent to a specific AI model, or give it a prioritized list of models to try:
+
+```yaml
+---
+name: my-agent
+description: An agent that prefers fast models.
+# Single model:
+model: gpt-5.4-mini
+---
+```
+
+Or, for a fallback list:
+
+```yaml
+---
+name: my-agent
+description: An agent with a model fallback list.
+# Tried in order — uses the first one available to you
+model:
+  - claude-sonnet-4.6
+  - gpt-5.4-mini
+# Optional: prevent users from switching to a model outside this list
+model-policy: required
+---
+```
+
+> 💡 **Why list multiple models?** If your preferred model isn't available (e.g., usage limit reached or not enabled for your plan), Copilot automatically tries the next one. This makes your agent more resilient.
+
 > 📖 **Official docs**: [Custom agents configuration](https://docs.github.com/copilot/reference/custom-agents-configuration)
->
-> ⚠️ **VS Code Only**: The `model` property (for selecting AI models) works in VS Code but is not supported in GitHub Copilot CLI. You can safely include it for cross-platform agent files. GitHub Copilot CLI will ignore it.
 
 ### More Agent Templates
 

--- a/06-mcp-servers/README.md
+++ b/06-mcp-servers/README.md
@@ -932,6 +932,8 @@ These work when you're already inside `copilot`:
 | `/mcp delete <server-name>` | Remove a server permanently |
 | `/mcp auth <server-name>` | Re-authenticate with an MCP server that uses OAuth (e.g., after switching accounts) |
 
+> 💡 **Plugins Dashboard**: When you run `/mcp add`, `/mcp edit`, or `/mcp auth`, the form opens inside the **plugins dashboard** — a unified panel for managing MCP servers, skills, and plugins. Closing a form returns you to the server list automatically. You can also open the dashboard directly by running `/plugin` or `/mcp`.
+
 ### Option 2: `copilot mcp` command (from your terminal)
 
 You can also manage MCP servers directly from your terminal without starting a chat session first:


### PR DESCRIPTION
## What changed in Copilot CLI v1.0.83

Two beginner-relevant changes were shipped in [v1.0.83](https://github.com/github/copilot-cli/releases/tag/v1.0.83) (released 2026-09-04):

1. **Custom agents can now specify multiple models** — The `model` property in `.agent.md` files now works in GitHub Copilot CLI (not just VS Code). You can provide a single model ID or a prioritized list; Copilot tries them in order until one is available. The new `model-policy: required` field locks agents to the specified list.

2. **MCP add/edit/auth forms now open in the plugins dashboard** — When you run `/mcp add`, `/mcp edit <name>`, or `/mcp auth <name>`, the form opens inside the unified plugins dashboard instead of a separate panel. Closing the form returns you to the server list automatically.

## What was updated

### Chapter 04 — Agents & Custom Instructions
- Removed outdated `⚠️ VS Code Only` callout that said the `model` property was not supported in Copilot CLI.
- Added `model` and `model-policy` rows to the YAML Properties table.
- Added a new **Specifying Models in an Agent** subsection with YAML examples showing both a single model and a fallback list, plus a tip explaining why a list is useful.

### Chapter 06 — MCP Servers
- Added a `💡 Plugins Dashboard` callout below the slash-commands table explaining that interactive MCP management forms now open inside the plugins dashboard.

## Sources
- [v1.0.83 release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.83)
- [Copilot CLI changelog](https://github.com/github/copilot-cli/blob/main/changelog.md)




> Generated by [Course Updater](https://github.com/github/copilot-cli-for-beginners/actions/runs/34117831998/agentic_workflow) · ● 748.9K · [◷](https://github.com/search?q=repo%3Agithub%2Fcopilot-cli-for-beginners+%22gh-aw-workflow-id%3A+course-updater%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Course Updater, engine: copilot, model: auto, id: 34117831998, workflow_id: course-updater, run: https://github.com/github/copilot-cli-for-beginners/actions/runs/34117831998 -->

<!-- gh-aw-workflow-id: course-updater -->